### PR TITLE
Refactor weight decay on BatchNorm handling (#554)

### DIFF
--- a/vissl/ssl_tasks/ssl_task.py
+++ b/vissl/ssl_tasks/ssl_task.py
@@ -386,7 +386,9 @@ class SelfSupervisionTask(ClassificationTask):
 
         # initialize the pytorch optimizer now since the model has been moved to
         # the appropriate device
-        self.optimizer.init_pytorch_optimizer(self.base_model)
+        self.prepare_optimizer(
+            optimizer=self.optimizer, model=self.base_model, loss=self.loss
+        )
         if self.amp_args is not None and is_apex_available():
             # Allow Amp to perform casts as specified by the amp_args.
             # This updates the model and the PyTorch optimizer (which is wrapped


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/ClassyVision/pull/554

Sending this for review early due to S204449. Tests/lint will be fixed later.

The way we implement weight decay on batch norm is too rigid: each model is
expected to implement a method returning the BatchNorm parameters. In practice, all models implement that method the same way and it causes boilerplate in the config handling/constructors. In addition to that, users of ClassyOptimizer do not have control over the param groups passed to the underlying PyTorch optimizer. This is an issue for implementing features like discriminative learning rates.

This refactors ClassyOptimizer to accept two sets of param groups. One set will be updated according to the schedulers (LR, WD etc), another one (frozen_param_groups) will get scheduled but whatever values were present in that param group originally will stay as they are. This is needed so we can still change the learning rate on an optimizer that has a frozen weight decay (since the WD is set by a "constant" scheduler).

Differential Revision: D22186394

