### PR TITLE
Consistent "output_batch" declaration accross collators

### DIFF
--- a/vissl/data/collators/multicrop_collator.py
+++ b/vissl/data/collators/multicrop_collator.py
@@ -25,9 +25,11 @@ def multicrop_collator(batch):
             output_data_idx.append(data_idx[idx][pos])
         output_data.append(torch.stack(_output_data))
 
-    output_batch = {}
-    output_batch["data"] = [output_data]
-    output_batch["label"] = [torch.stack(output_label)]
-    output_batch["data_valid"] = [torch.stack(output_data_valid)]
-    output_batch["data_idx"] = [torch.stack(output_data_idx)]
+    output_batch = {
+        "data": [output_data],
+        "label": [torch.stack(output_label)],
+        "data_valid": [torch.stack(output_data_valid)],
+        "data_idx": [torch.stack(output_data_idx)],
+    }
+
     return output_batch

--- a/vissl/data/collators/patch_and_image_collator.py
+++ b/vissl/data/collators/patch_and_image_collator.py
@@ -29,6 +29,7 @@ def patch_and_image_collator(batch):
     for idx in range(batch_size):
         patch_list.extend(data[idx][1:])
     patches = torch.stack(patch_list)
+
     output_batch = {
         "images": [images],
         "patches": [patches],

--- a/vissl/data/collators/siamese_collator.py
+++ b/vissl/data/collators/siamese_collator.py
@@ -42,6 +42,7 @@ def siamese_collator(batch):
         if should_flatten:
             idx_labels = idx_labels.flatten()
         output_label.append(idx_labels)
-    output_batch = {}
-    output_batch["data"], output_batch["label"] = output_data, output_label
+
+    output_batch = {"data": output_data, "label": output_label}
+
     return output_batch

--- a/vissl/data/collators/simclr_collator.py
+++ b/vissl/data/collators/simclr_collator.py
@@ -26,9 +26,10 @@ def simclr_collator(batch):
             output_data_valid.append(data_valid[idx][pos])
             output_data_idx.append(data_idx[idx][pos])
 
-    output_batch = {}
-    output_batch["data"] = [torch.stack(output_data)]
-    output_batch["label"] = [torch.stack(output_label)]
-    output_batch["data_valid"] = [torch.stack(output_data_valid)]
-    output_batch["data_idx"] = [torch.stack(output_data_idx)]
+    output_batch = {
+        "data": [torch.stack(output_data)],
+        "label": [torch.stack(output_label)],
+        "data_valid": [torch.stack(output_data_valid)],
+        "data_idx": [torch.stack(output_data_idx)],
+    }
     return output_batch


### PR DESCRIPTION
Summary:
- remove "output_batch" repetition
- make it a bit more pythonic (single assignment)

I'm well aware that this is super minor :) I was just dropping by

Differential Revision: D22427200

