### PR TITLE
wrap classy_vision's RegNet

### DIFF
--- a/configs/config/benchmark/linear_image_classification/imagenet1k/regnet1.6G.yaml
+++ b/configs/config/benchmark/linear_image_classification/imagenet1k/regnet1.6G.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+config:
+  METERS:
+    accuracy_list:
+      num_list: 1
+      topk: [1, 5]
+  MODEL:
+    EVAL_FEATURES: ["res5"]
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_1.6gf
+      LINEAR_FEAT_POOL_OPS: [
+          ["AdaptiveAvgPool2d", [[4, 3]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 888, "dims": [10656, 1000]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/imagenet1k/regnet3.2G.yaml
+++ b/configs/config/benchmark/linear_image_classification/imagenet1k/regnet3.2G.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+config:
+  METERS:
+    accuracy_list:
+      num_list: 1
+      topk: [1, 5]
+  MODEL:
+    EVAL_FEATURES: ["res5"]
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_3.2gf
+      LINEAR_FEAT_POOL_OPS: [
+          ["AvgPool2d", [[3, 3], 2, 0]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 1512, "dims": [9792, 1000]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/imagenet1k/regnet400MF.yaml
+++ b/configs/config/benchmark/linear_image_classification/imagenet1k/regnet400MF.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+config:
+  METERS:
+    accuracy_list:
+      num_list: 1
+      topk: [1, 5]
+  MODEL:
+    EVAL_FEATURES: ["res5"]
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_400mf
+      LINEAR_FEAT_POOL_OPS: [
+          ["AdaptiveAvgPool2d", [[6, 5]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 440, "dims": [8640, 1000]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/imagenet1k/regnet800MF.yaml
+++ b/configs/config/benchmark/linear_image_classification/imagenet1k/regnet800MF.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+config:
+  METERS:
+    accuracy_list:
+      num_list: 1
+      topk: [1, 5]
+  MODEL:
+    EVAL_FEATURES: ["res5"]
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_800mf
+      LINEAR_FEAT_POOL_OPS: [
+          ["AdaptiveAvgPool2d", [[4, 3]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 768, "dims": [9216, 1000]}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet1.6G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet1.6G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_1.6gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [888, 888], "use_relu": True}],
+        ["mlp", {"dims": [888, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet128G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet128G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_128gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [7392, 7392], "use_relu": True}],
+        ["mlp", {"dims": [7392, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet16G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet16G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_16gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [3024, 3024], "use_relu": True}],
+        ["mlp", {"dims": [3024, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet256G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet256G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_256gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [5088, 5088], "use_relu": True}],
+        ["mlp", {"dims": [5088, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet3.2G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet3.2G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_3.2gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [1512, 1512], "use_relu": True}],
+        ["mlp", {"dims": [1512, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet32G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet32G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_32gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [3712, 3712], "use_relu": True}],
+        ["mlp", {"dims": [3712, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet400mf.yaml
+++ b/configs/config/pretrain/simclr/models/regnet400mf.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_400mf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [440, 440], "use_relu": True}],
+        ["mlp", {"dims": [440, 128]}]
+      ]

--- a/configs/config/pretrain/simclr/models/regnet64G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet64G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_64gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [2976, 2976], "use_relu": True}],
+        ["mlp", {"dims": [2976, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/simclr/models/regnet800mf.yaml
+++ b/configs/config/pretrain/simclr/models/regnet800mf.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_800mf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [768, 768], "use_relu": True}],
+        ["mlp", {"dims": [768, 128]}]
+      ]

--- a/configs/config/pretrain/simclr/models/regnet8G.yaml
+++ b/configs/config/pretrain/simclr/models/regnet8G.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_8gf
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [2016, 2016], "use_relu": True}],
+        ["mlp", {"dims": [2016, 128], "use_relu": False}],
+      ]

--- a/configs/config/pretrain/swav/models/regnet1.6G.yaml
+++ b/configs/config/pretrain/swav/models/regnet1.6G.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_1.6gf
+    HEAD:
+      PARAMS: [
+        ["swav_head", {"dims": [888, 888, 128], "use_bn": True, "nmb_clusters": [3000]}],
+      ]

--- a/configs/config/pretrain/swav/models/regnet3.2G.yaml
+++ b/configs/config/pretrain/swav/models/regnet3.2G.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_3.2gf
+    HEAD:
+      PARAMS: [
+        ["swav_head", {"dims": [1512, 1512, 128], "use_bn": True, "nmb_clusters": [3000]}],
+      ]

--- a/configs/config/pretrain/swav/models/regnet400mf.yaml
+++ b/configs/config/pretrain/swav/models/regnet400mf.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_400mf
+    HEAD:
+      PARAMS: [
+        ["swav_head", {"dims": [440, 440, 128], "use_bn": True, "nmb_clusters": [3000]}],
+      ]

--- a/configs/config/pretrain/swav/models/regnet800mf.yaml
+++ b/configs/config/pretrain/swav/models/regnet800mf.yaml
@@ -1,0 +1,12 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        REGNET:
+          name: regnet_y_800mf
+    HEAD:
+      PARAMS: [
+        ["swav_head", {"dims": [768, 768, 128], "use_bn": True, "nmb_clusters": [3000]}],
+      ]

--- a/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
+++ b/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
@@ -1,0 +1,113 @@
+# @package _global_
+config:
+  VERBOSE: False
+  LOG_FREQUENCY: 10
+  TEST_ONLY: False
+  TEST_MODEL: False
+  SEED_VALUE: 0
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 0
+    TRAIN:
+      DATA_SOURCES: [synthetic]
+      BATCHSIZE_PER_REPLICA: 2
+      LABEL_TYPE: sample_index
+      TRANSFORMS:
+        - name: ImgReplicatePil
+          num_times: 2
+        - name: RandomResizedCrop
+          size: 224
+        - name: RandomHorizontalFlip
+          p: 0.5
+        - name: ImgPilColorDistortion
+          strength: 1.0
+        - name: ImgPilGaussianBlur
+          p: 0.5
+          radius_min: 0.1
+          radius_max: 2.0
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      COLLATE_FUNCTION: simclr_collator
+      MMAP_MODE: True
+      DATA_LIMIT: 4
+      DROP_LAST: True
+      COPY_TO_LOCAL_DISK: False
+  TRAINER:
+    TRAIN_STEP_NAME: standard
+  METERS: null
+  MODEL:
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        # These params are for RegNetY 200Mflops from here:
+        #   /mnt/vol/gfsai-bistro2-east/ai-group/bistro/gpu/mannatsingh/regnety_configs/regnety_200m.json
+        REGNET:
+          # The w_0, w_a and w_m params will compute the following config, e.g. same as the json above.
+          #   depth: sum([1, 1, 4, 7]) = 13
+          #   width: [24, 56, 152, 368]
+          depth: 13
+          w_0: 24
+          w_a: 35.5
+          w_m: 2.49
+          group_width: 8
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [368, 368], "use_relu": True}],
+        ["mlp", {"dims": [368, 128]}]
+      ]
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: pytorch
+      GROUP_SIZE: 2
+  CRITERION:
+      name: simclr_info_nce_loss
+      SIMCLR_INFO_NCE_LOSS:
+        TEMPERATURE: 0.1
+        BUFFER_PARAMS:
+          EMBEDDING_DIM: 128
+  OPTIMIZER:
+      name: sgd
+      use_larc: True
+      larc_config:
+        clip: False
+        trust_coefficient: 0.001
+        eps: 0.00000001
+      weight_decay: 0.000001
+      momentum: 0.9
+      nesterov: False
+      num_epochs: 1
+      regularize_bn: False
+      regularize_bias: True
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.3
+            base_lr_batch_size: 256
+          name: composite
+          schedulers:
+            - name: linear
+              start_value: 0.6
+              end_value: 1.2
+            - name: cosine
+              start_value: 1.2
+              end_value: 0.0000
+          update_interval: step
+          interval_scaling: [rescaled, fixed]
+          lengths: [0.1, 0.9]             # 100ep
+  DISTRIBUTED:
+    BACKEND: gloo
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 1
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: cpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 5
+    OVERWRITE_EXISTING: true

--- a/configs/config/test/integration_test/quick_simclr_regnet.yaml
+++ b/configs/config/test/integration_test/quick_simclr_regnet.yaml
@@ -1,0 +1,111 @@
+# @package _global_
+config:
+  VERBOSE: False
+  LOG_FREQUENCY: 2
+  TEST_ONLY: False
+  TEST_MODEL: False
+  SEED_VALUE: 0
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [disk_folder]
+      DATASET_NAMES: [imagenet1k_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      LABEL_TYPE: sample_index    # just an implementation detail. Label isn't used
+      TRANSFORMS:
+        - name: ImgReplicatePil
+          num_times: 2
+        - name: RandomResizedCrop
+          size: 224
+        - name: RandomHorizontalFlip
+          p: 0.5
+        - name: ImgPilColorDistortion
+          strength: 1.0
+        - name: ImgPilGaussianBlur
+          p: 0.5
+          radius_min: 0.1
+          radius_max: 2.0
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      COLLATE_FUNCTION: simclr_collator
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/imagenet1k/
+      DATA_LIMIT: 500
+      DROP_LAST: True
+  TRAINER:
+    TRAIN_STEP_NAME: standard
+  METERS: null
+  MODEL:
+    MODEL_COMPLEXITY:
+      COMPUTE_COMPLEXITY: False
+      INPUT_SHAPE: [3, 224, 224]
+    TRUNK:
+      NAME: regnet
+      TRUNK_PARAMS:
+        # These params are for RegNetY 200Mflops from here:
+        #   /mnt/vol/gfsai-bistro2-east/ai-group/bistro/gpu/mannatsingh/regnety_configs/regnety_200m.json
+        REGNET:
+          # The w_0, w_a and w_m params will compute the following config, e.g. same as the json above.
+          #   depth: sum([1, 1, 4, 7]) = 13
+          #   width: [24, 56, 152, 368]
+          depth: 13
+          w_0: 24
+          w_a: 35.5
+          w_m: 2.49
+          group_width: 8
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [368, 368], "use_relu": True}],
+        ["mlp", {"dims": [368, 128]}]
+      ]
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: pytorch
+  CRITERION:
+      name: simclr_info_nce_loss
+      SIMCLR_INFO_NCE_LOSS:
+        TEMPERATURE: 0.1
+        BUFFER_PARAMS:
+          EMBEDDING_DIM: 128
+  OPTIMIZER:
+      name: sgd
+      use_larc: True
+      larc_config:
+        clip: False
+        trust_coefficient: 0.001
+        eps: 0.00000001
+      weight_decay: 0.000001
+      momentum: 0.9
+      nesterov: False
+      num_epochs: 2
+      regularize_bn: False
+      regularize_bias: True
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.3
+            base_lr_batch_size: 256
+          name: cosine
+          start_value: 0.15   # LR for batch size 256
+          end_value: 0.0000
+          update_interval: step
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    # NUM_PROC_PER_NODE: 2
+    NUM_PROC_PER_NODE: 1
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 5
+    OVERWRITE_EXISTING: true

--- a/dev/run_quick_tests.sh
+++ b/dev/run_quick_tests.sh
@@ -6,12 +6,13 @@ SRC_DIR=$(dirname "${SRC_DIR}")
 BINARY="python ${SRC_DIR}/tools/distributed_train.py"
 
 CFG_LIST=(
-    "test/integration_test/quick_simclr"
-    "test/integration_test/quick_simclr_multicrop"
-    "test/integration_test/quick_pirl"
-    "test/integration_test/quick_simclr_efficientnet"
-    "test/integration_test/quick_swav"
     "test/integration_test/quick_deepcluster_v2"
+    "test/integration_test/quick_pirl"
+    "test/integration_test/quick_simclr"
+    "test/integration_test/quick_simclr_efficientnet"
+    "test/integration_test/quick_simclr_multicrop"
+    "test/integration_test/quick_simclr_regnet"
+    "test/integration_test/quick_swav"
 )
 
 echo "========================================================================"

--- a/vissl/models/trunks/__init__.py
+++ b/vissl/models/trunks/__init__.py
@@ -6,6 +6,7 @@ from vissl.models.trunks.alexnet_deepcluster import AlexNetDeepCluster
 from vissl.models.trunks.alexnet_jigsaw import AlexNetJigsaw
 from vissl.models.trunks.alexnet_rotnet import AlexNetRotNet
 from vissl.models.trunks.efficientnet import EfficientNet
+from vissl.models.trunks.regnet import RegNet
 from vissl.models.trunks.resnext import ResNeXt
 
 
@@ -15,8 +16,9 @@ TRUNKS = {
     "alexnet_deepcluster": AlexNetDeepCluster,
     "alexnet_jigsaw": AlexNetJigsaw,
     "alexnet_rotnet": AlexNetRotNet,
-    "resnet": ResNeXt,
     "efficientnet": EfficientNet,
+    "regnet": RegNet,
+    "resnet": ResNeXt,
 }
 
 

--- a/vissl/models/trunks/regnet.py
+++ b/vissl/models/trunks/regnet.py
@@ -1,0 +1,63 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import logging
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+from classy_vision.models import RegNet as ClassyRegNet, build_model
+from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs
+
+
+class RegNet(nn.Module):
+    """
+    Wrapper for ClassyVision RegNet model so we can map layers into feature
+    blocks to facilitate feature extraction and benchmarking at several layers.
+
+    This model is defined on the fly from a RegNet base class and a configuration file.
+
+    We follow the feature naming convention defined in the ResNet vissl trunk.
+    """
+
+    def __init__(self, model_config, model_name):
+        super().__init__()
+
+        assert model_config.INPUT_TYPE in ["rgb", "bgr"], "Input type not supported"
+        trunk_config = model_config.TRUNK.TRUNK_PARAMS.REGNET
+
+        if "name" in trunk_config:
+            name = trunk_config["name"]
+            logging.info(f"Building model: RegNet: {name}")
+            model = build_model({"name": name})
+        else:
+            logging.info("Building model: RegNet from yaml config")
+            model = ClassyRegNet.from_config(trunk_config)
+
+        # Now map the models to the structure we want to expose for SSL tasks
+        # The upstream RegNet model is made of :
+        # - `stem`
+        # - n x blocks in trunk_output, named `block1, block2, ..`
+
+        # We're only interested in the stem and successive blocks
+        # everything else is not picked up on purpose
+        feature_blocks: List[Tuple[str, nn.Module]] = []
+
+        # - get the stem
+        feature_blocks.append(("conv1", model.stem))
+
+        # - get all the feature blocks
+        for k, v in model.trunk_output.named_children():
+            assert k.startswith("block"), f"Unexpected layer name {k}"
+            block_index = len(feature_blocks) + 1
+            feature_blocks.append((f"res{block_index}", v))
+
+        # - finally, add avgpool and flatten.
+        feature_blocks.append(("avgpool", nn.AdaptiveAvgPool2d((1, 1))))
+        feature_blocks.append(("flatten", Flatten(1)))
+
+        self._feature_blocks = nn.ModuleDict(feature_blocks)
+
+    def forward(self, x, out_feat_keys: List[str] = None) -> List[torch.Tensor]:
+        return get_trunk_forward_outputs(
+            feat=x, out_feat_keys=out_feat_keys, feature_blocks=self._feature_blocks
+        )


### PR DESCRIPTION
Summary:
[vissl] wrap classy_vision's RegNet

- this change wraps classy_vision RegNet in VISSL.
- layers are mapped to features for vissl.
- moved regnet.py out of fb dir.
- moved regnet yaml files out of fb dir.
- built 200mf regnet models for quick testing in two of the yaml files.
- added regnet to circleci test too.

Differential Revision: D22567510

