### PR TITLE
Make the hive table data download script save data in chunks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ cython
 scikit-learn
 parameterized==0.7.4
 opencv-python==3.4.2.17
-numpy==1.14.5
+numpy>=1.15
 tabulate
 pycocotools>=2.0.1

--- a/vissl/utils/checkpoint.py
+++ b/vissl/utils/checkpoint.py
@@ -2,9 +2,6 @@
 
 import logging
 import os
-import tempfile
-import traceback
-from shutil import copy2, move
 from typing import Any, Dict, List
 
 import torch


### PR DESCRIPTION
Summary: in VISSL, for instagram training, we save the everstore handles to the file on disk. For large data sizes like billions , scraping the full data table and keeping the everstore handles in memory will not work since we will OOM. instead, allow to scrape data and save in several chunks. so for example, save 1B images in 10 chunks - each chunk of size 100M.

Differential Revision: D22766834

