### PR TITLE
Bump circleCI so it can track latest classy vision master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,15 @@ install_python: &install_python
         pyenv install 3.6.1
         pyenv global 3.6.1
 
+
+install_classy_vision: &install_classy_vision
+  - run:
+      name: Install ClassyVision
+      working_directory: ~/
+      command: |
+        pip uninstall -y classy_vision
+        pip install classy-vision@https://github.com/facebookresearch/ClassyVision/tarball/master
+
 setupcuda: &setupcuda
   run:
     name: Setup CUDA and NVIDIA driver
@@ -71,7 +80,7 @@ install_vissl_dep: &install_vissl_dep
       name: Install Dependencies
       working_directory: ~/vissl
       command: |
-        pip install --progress-bar off torch torchvision
+        pip install --progress-bar off torch==1.5.0 torchvision==0.6.0
         pip install --progress-bar off -r requirements.txt
 
 install_apex_gpu: &install_apex_gpu
@@ -119,16 +128,17 @@ jobs:
       # Cache the vissl_venv directory that contains dependencies
       - restore_cache:
           keys:
-            - v1-cpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}
+            - v2-cpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}
 
       - <<: *install_vissl_dep
+      - <<: *install_classy_vision
       - <<: *install_apex_cpu
       - <<: *pip_list
 
       - save_cache:
           paths:
             - ~/vissl_venv
-          key: v1-cpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}
+          key: v2-cpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}
 
       - <<: *install_vissl
 
@@ -161,9 +171,10 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-gpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}-{{ checksum "docker/common/install_apex.sh" }}
+            - v2-gpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}-{{ checksum "docker/common/install_apex.sh" }}
 
       - <<: *install_vissl_dep
+      - <<: *install_classy_vision
       - <<: *install_apex_gpu
       - <<: *pip_list
 
@@ -174,7 +185,7 @@ jobs:
       - save_cache:
           paths:
             - ~/vissl_venv
-          key: v1-gpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}-{{ checksum "docker/common/install_apex.sh" }}
+          key: v2-gpu-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "setup.py" }}-{{ checksum "docker/common/install_apex.sh" }}
 
       - <<: *install_vissl
 

--- a/MODEL_ZOO.md
+++ b/MODEL_ZOO.md
@@ -110,7 +110,7 @@ VISSL is 100% compatible with TorchVision ResNet models. You can benchmark these
 ### SwAV
 <!-- swav -->
 - rn50 - 2x224 + 6x96 - 100ep - 8node: /mnt/vol/gfsai-bistro2-east/ai-group/bistro/gpu/prigoyal/ssl_framework/swav_in1k_rn50_100ep_swav_8node_resnet_27_07_20.7e6fc6bf/model_final_checkpoint_phase99.torch
-- rn50 - 2x224 + 6x96 - 200ep - 8node:
+- rn50 - 2x224 + 6x96 - 200ep - 8node: /mnt/vol/gfsai-bistro2-east/ai-group/bistro/gpu/prigoyal/ssl_framework/swav_in1k_rn50_200ep_swav_8node_resnet_27_07_20.bd595bb0/model_final_checkpoint_phase199.torch
 - rn50 - 2x224 + 6x96 - 400ep - 8node:
 - rn50 - 2x224 + 6x96 - 800ep - 8node:
 - rn50 - 2x224 + 6x96 - 200ep - 1node - use queue:

--- a/dev/packaging/conda/vissl/meta.yaml
+++ b/dev/packaging/conda/vissl/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - python
     - setuptools
     - torchvision>=0.5
-    - tensorboard>=1.14
+    - tensorboard>=1.15
     - opencv
     - scipy
     - scikit-learn
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - torchvision>=0.5
-    - tensorboard>=1.14
+    - tensorboard>=1.15
     - opencv
     - scipy
     - scikit-learn

--- a/dev/run_quick_tests.sh
+++ b/dev/run_quick_tests.sh
@@ -27,10 +27,11 @@ for cfg in "${CFG_LIST[@]}"; do
     CHECKPOINT_DIR=$(mktemp -d)
     # shellcheck disable=SC2102
     # shellcheck disable=SC2086
-    $BINARY config=$cfg \
+    CUDA_LAUNCH_BLOCKING=1 $BINARY config=$cfg \
         config.DATA.TRAIN.DATA_SOURCES=[synthetic] \
         hydra.verbose=true \
         config.TENSORBOARD_SETUP.USE_TENSORBOARD=true \
-        config.CHECKPOINT.DIR="$CHECKPOINT_DIR"
+        config.CHECKPOINT.DIR="$CHECKPOINT_DIR" && echo "TEST OK" || exit
+
     rm -rf $CHECKPOINT_DIR
 done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorboard==1.14.0
+tensorboard==1.15.0
 hydra-core@https://github.com/facebookresearch/hydra/tarball/8ac24
 classy-vision@https://github.com/facebookresearch/ClassyVision/tarball/master
 faiss==1.5.3


### PR DESCRIPTION
Summary: given change in core classy vision https://www.internalfb.com/intern/diff/D22634936 (https://github.com/facebookresearch/vissl/commit/2a1cc9489aa343aa015a4c43c4645dcd69a880bb)/, have to make this bump

Differential Revision: D22801248

