### PR TITLE
Classy Optimizer refactor

### DIFF
--- a/vissl/ssl_hooks/log_hooks.py
+++ b/vissl/ssl_hooks/log_hooks.py
@@ -88,7 +88,7 @@ class LogLossLrEtaHook(ClassyHook):
 
                 eta_secs = avg_time * (task.max_iteration - iteration)
                 eta_string = str(datetime.timedelta(seconds=int(eta_secs)))
-                lr_val = round(task.optimizer.parameters.lr, 5)
+                lr_val = round(task.optimizer.options_view.lr, 5)
                 batch_time = int(1000.0 * avg_time)
                 rank = get_rank()
                 log_str = (

--- a/vissl/ssl_tasks/ssl_task.py
+++ b/vissl/ssl_tasks/ssl_task.py
@@ -8,7 +8,7 @@ import torch
 from classy_vision.generic.util import copy_model_to_gpu
 from classy_vision.losses import build_loss
 from classy_vision.meters import build_meter
-from classy_vision.optim import build_optimizer
+from classy_vision.optim import build_optimizer, build_optimizer_schedulers
 from classy_vision.tasks import ClassificationTask, register_task
 from classy_vision.tasks.classification_task import BroadcastBuffersMode
 from vissl.data import build_dataset, get_loader
@@ -186,6 +186,9 @@ class SelfSupervisionTask(ClassificationTask):
         optim = build_optimizer(optimizer_config)
         return optim
 
+    def _build_optimizer_schedulers(self):
+        return build_optimizer_schedulers(self.config["OPTIMIZER"])
+
     def _build_loss(self):
         # in some cases like memory bank, we need to store the size of data
         # as we use it to allocate memory. Hence we set that parameter here.
@@ -328,13 +331,6 @@ class SelfSupervisionTask(ClassificationTask):
         # set the model to train or eval depending on what phase we are in
         self.base_model.train(phase["train"])
 
-        # update the optimizer
-        # Here, the state.num_updates is used to calculate where we are in the
-        # training. If we are resuming, the state.num_updates will be restored
-        # and used to calculate the proper LR to use
-        if self.train and self.train_phase_idx >= 0:
-            self.optimizer.update_schedule_on_epoch(self.where)
-
     def _update_classy_state(self, device, state_dict=None):
         """
         Updates classy state with the provided state dict from a checkpoint.
@@ -371,21 +367,27 @@ class SelfSupervisionTask(ClassificationTask):
             model_config=self.config["MODEL"],
             optimizer_config=self.config["OPTIMIZER"],
         )
-        param_groups, frozen_param_groups = [], None
+        param_groups = []
         # regularized params. Users can append other options here
         # like different LR for the params
         if len(optim_params["regularized_params"]) != 0:
-            param_groups.append({"params": optim_params["regularized_params"]})
+            param_groups.append(
+                {
+                    "params": optim_params["regularized_params"],
+                    **self.optimizer_schedulers,
+                }
+            )
 
         # params which are not regularized i.e have weight_decay=0. common for BN
         if len(optim_params["unregularized_params"]) != 0:
-            frozen_param_groups = {
+            frozen_param_group = {
                 "params": optim_params["unregularized_params"],
-                "weight_decay": 0.0,
+                **self.optimizer_schedulers,
             }
-        self.optimizer.set_param_groups(
-            param_groups=param_groups, frozen_param_groups=frozen_param_groups
-        )
+            frozen_param_group["weight_decay"] = 0.0
+            param_groups.append(frozen_param_group)
+
+        self.optimizer.set_param_groups(param_groups)
 
     def prepare(self, device: str, pin_memory: bool = False):
         """
@@ -400,6 +402,7 @@ class SelfSupervisionTask(ClassificationTask):
         self.base_loss = self._build_loss()
         self.meters = self._build_meters()
         self.optimizer = self._build_optimizer()
+        self.optimizer_schedulers = self._build_optimizer_schedulers()
         self.iteration = self.iteration
         self.num_train_phases = num_train_phases
 

--- a/vissl/ssl_trainer/train_steps/standard_train_step.py
+++ b/vissl/ssl_trainer/train_steps/standard_train_step.py
@@ -147,10 +147,9 @@ def standard_train_step(task):  # NOQA
             else:
                 local_loss.backward()
 
-        task.optimizer.update_schedule_on_step(task.where)
         task.run_hooks(SSLClassyHookFunctions.on_backward.name)
         with PerfTimer("optimizer_step", perf_stats):
-            task.optimizer.step()
+            task.optimizer.step(where=task.where)
         task.run_hooks(SSLClassyHookFunctions.on_update.name)
         task.num_updates += task.get_global_batchsize()
 

--- a/vissl/ssl_trainer/trainer.py
+++ b/vissl/ssl_trainer/trainer.py
@@ -200,12 +200,6 @@ class DistributedSelfSupervisionTrainer(ClassyTrainer):
         # set the model to train or eval depending on what phase we are in
         task.model.train(phase["train"])
 
-        # update the optimizer
-        # Here, the task.num_updates is used to calculate where we are in the
-        # training. If we are resuming, the task.num_updates will be restored
-        # and used to calculate the proper LR to use
-        if task.train and task.train_phase_idx >= 0:
-            task.optimizer.update_schedule_on_epoch(task.where)
         local_rank, _ = get_machine_local_and_dist_rank()
         logging.info(f"Phase advanced. Rank: {local_rank}")
 


### PR DESCRIPTION
Summary:
This refactors ClassyOptimizer to make its API (roughly) match n293833. Major changes:
 * ClassyOptimizer no longer instantiates ParamSchedulers in its config. This gives us more flexibility to combine them however we want and change the config format;
 * ClassyOptimizer.set_param_groups() no longer has a frozen_param_groups argument. Each option in the param group can be a ParamScheduler instead. This allows implementing discriminative learning rates and disabling wd.bn in a cleaner way;
 * ClassyOptimizer no longer keeps a copy of the optimizer options, so we can no longer have inconsistency bugs; Added an `options_view` argument to allow getting the current LR in a convenient way (used in hooks);
 * ClassyOptimizer is now completely stateless! Trivial get/set_classy_state implementations;

Differential Revision: D22466936

