### PR TITLE
Hotfix

### DIFF
--- a/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
+++ b/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
@@ -20,13 +20,8 @@ config:
           size: 224
         - name: RandomHorizontalFlip
           p: 0.5
-        - name: ImgOpenCVColorDistortion
-          brightness: 0.8
-          contrast: 0.8
-          saturation: 0.8
-          hue: 0.2
-          p_color_distort: 0.8
-          p_grayscale: 0.2
+        - name: ImgPilColorDistortion
+          strength: 1.0
         - name: ImgPilGaussianBlur
           p: 0.5
           radius_min: 0.1

--- a/vissl/ssl_hooks/tensorboard_hook.py
+++ b/vissl/ssl_hooks/tensorboard_hook.py
@@ -98,7 +98,7 @@ class SSLTensorboardHook(ClassyHook):
 
             self.tb_writer.add_scalar(
                 tag="Training/Learning_rate",
-                scalar_value=round(task.optimizer.parameters.lr, 5),
+                scalar_value=round(task.optimizer.options_view.lr, 5),
                 global_step=iteration,
             )
 


### PR DESCRIPTION
Summary: removing the call to a fb-specific piece of code in a unit test

Differential Revision: D22977081

