### PR TITLE
minor cleanup

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -442,7 +442,7 @@ config:
     # every training run should have a unique id. Following are the options:
     #   1. If using INIT_METHOD=env, RUN_ID="" is fine.
     #   2. If using INIT_METHOD=tcp,
-    #      - if you use > 1 machine, set port yourself. RUN_ID="127.0.0.1:{port}".
+    #      - if you use > 1 machine, set port yourself. RUN_ID="localhost:{port}".
     #      - If using 1 machine, set RUN_ID=auto and a free port will be automatically selected
     #   3. IF using INIT_METHOD=file, RUN_ID={file_path}
     RUN_ID: ""

--- a/vissl/utils/misc.py
+++ b/vissl/utils/misc.py
@@ -46,7 +46,7 @@ def get_dist_run_id(cfg, num_nodes):
             num_nodes == 1
         ), "cfg.DISTRIBUTED.RUN_ID=auto is allowed for 1 machine only."
         port = find_free_tcp_port()
-        run_id = f"127.0.0.1:{port}"
+        run_id = f"localhost:{port}"
     elif init_method == "file":
         if num_nodes > 1:
             logging.warning(


### PR DESCRIPTION
Summary:
[vissl]: minor cleanup on ondemand GPU

- use localhost instead of 127.0.0.1. Otherwise, it hangs on IPv6 machines.
- updated the doc on different datasets after I figured out that's reason for
  ondemand server to work.

Differential Revision: D23047520

