### PR TITLE
Wider PIRL models + MLP Head

### DIFF
--- a/configs/config/pretrain/pirl/epochs/epochs_200.yaml
+++ b/configs/config/pretrain/pirl/epochs/epochs_200.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+config:
+  OPTIMIZER:
+      num_epochs: 200

--- a/configs/config/pretrain/pirl/models/resnet50_mlphead.yaml
+++ b/configs/config/pretrain/pirl/models/resnet50_mlphead.yaml
@@ -1,0 +1,42 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        # head 0 that operates on patches
+        [
+            ["mlp", {"dims": [2048, 2048, 128], "use_bn": False, "use_relu": True}],
+            ["siamese_concat_view", {"num_towers": 9}],
+            ["mlp", {"dims": [1152, 128]}],
+        ],
+        # head 1 that operates on images
+          [
+              ["mlp", {"dims": [2048, 2048, 128], "use_relu": True}]
+          ],
+        ]
+  LOSS:
+    name: nce_loss_with_memory
+    nce_loss_with_memory:
+      loss_type: "cross_entropy"
+      ignore_index: -1
+      norm_embedding: True
+      temperature: 0.1
+      loss_weights: [0.5, 0.5]  # relative weight of Patches=>Mem and Images=>Mem
+      norm_constant: -1
+      negative_sampling_params:
+        num_negatives: 32000
+        type: random
+      memory_params:
+        memory_size: -1 # auto_filled as num_train_samples
+        embedding_dim: 128
+        momentum: 0.5
+        norm_init: True
+        update_mem_on_forward: False
+      update_mem_with_emb_index: 1
+      num_train_samples: 1281167
+

--- a/configs/config/pretrain/pirl/models/resnet50_w2.yaml
+++ b/configs/config/pretrain/pirl/models/resnet50_w2.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+          WIDTH_MULTIPLIER: 2
+    HEAD:
+      PARAMS: [
+        # head 0 that operates on patches
+        [
+            ["mlp", {"dims": [4096, 128], "use_bn": False, "use_relu": False}],
+            ["siamese_concat_view", {"num_towers": 9}],
+            ["mlp", {"dims": [1152, 128]}],
+        ],
+        # head 1 that operates on images. Linear projection.
+          [
+              ["mlp", {"dims": [4096, 128]}]
+          ],
+        ]
+    AMP_PARAMS:
+      USE_AMP: True
+      AMP_ARGS: {"opt_level": "O1"}
+  OPTIMIZER:
+      num_epochs: 400

--- a/configs/config/pretrain/pirl/models/resnet50_w2_mlphead.yaml
+++ b/configs/config/pretrain/pirl/models/resnet50_w2_mlphead.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+          WIDTH_MULTIPLIER: 2
+    HEAD:
+      PARAMS: [
+        # head 0 that operates on patches
+        [
+            ["mlp", {"dims": [4096, 4096, 128], "use_bn": False, "use_relu": True}],
+            ["siamese_concat_view", {"num_towers": 9}],
+            ["mlp", {"dims": [1152, 128]}],
+        ],
+        # head 1 that operates on images. Linear projection.
+          [
+              ["mlp", {"dims": [4096, 4096, 128]}, "use_relu": True]
+          ],
+        ]
+    AMP_PARAMS:
+      USE_AMP: True
+      AMP_ARGS: {"opt_level": "O1"}
+  LOSS:
+    name: nce_loss_with_memory
+    nce_loss_with_memory:
+      loss_type: "cross_entropy"
+      ignore_index: -1
+      norm_embedding: True
+      temperature: 0.1
+      loss_weights: [0.5, 0.5]  # relative weight of Patches=>Mem and Images=>Mem
+      norm_constant: -1
+      negative_sampling_params:
+        num_negatives: 32000
+        type: random
+      memory_params:
+        memory_size: -1 # auto_filled as num_train_samples
+        embedding_dim: 128
+        momentum: 0.5
+        norm_init: True
+        update_mem_on_forward: False
+      update_mem_with_emb_index: 1
+      num_train_samples: 1281167
+  OPTIMIZER:
+      num_epochs: 400

--- a/configs/config/pretrain/pirl/models/resnet50_w4.yaml
+++ b/configs/config/pretrain/pirl/models/resnet50_w4.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+          WIDTH_MULTIPLIER: 4
+    HEAD:
+      PARAMS: [
+        # head 0 that operates on patches
+        [
+            ["mlp", {"dims": [8192, 128], "use_bn": False, "use_relu": False}],
+            ["siamese_concat_view", {"num_towers": 9}],
+            ["mlp", {"dims": [1152, 128]}],
+        ],
+        # head 1 that operates on images. Linear projection.
+          [
+              ["mlp", {"dims": [8192, 128]}]
+          ],
+        ]
+    AMP_PARAMS:
+      USE_AMP: True
+      AMP_ARGS: {"opt_level": "O1"}
+  OPTIMIZER:
+      num_epochs: 400

--- a/configs/config/pretrain/pirl/models/resnet50_w4_mlphead.yaml
+++ b/configs/config/pretrain/pirl/models/resnet50_w4_mlphead.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+config:
+  MODEL:
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+          WIDTH_MULTIPLIER: 4
+    HEAD:
+      PARAMS: [
+        # head 0 that operates on patches
+        [
+            ["mlp", {"dims": [8192, 8192, 128], "use_bn": False, "use_relu": True}],
+            ["siamese_concat_view", {"num_towers": 9}],
+            ["mlp", {"dims": [1152, 128]}],
+        ],
+        # head 1 that operates on images. Linear projection.
+          [
+              ["mlp", {"dims": [8192, 8192, 128]}, "use_relu": True]
+          ],
+        ]
+    AMP_PARAMS:
+      USE_AMP: True
+      AMP_ARGS: {"opt_level": "O1"}
+  LOSS:
+    name: nce_loss_with_memory
+    nce_loss_with_memory:
+      loss_type: "cross_entropy"
+      ignore_index: -1
+      norm_embedding: True
+      temperature: 0.1
+      loss_weights: [0.5, 0.5]  # relative weight of Patches=>Mem and Images=>Mem
+      norm_constant: -1
+      negative_sampling_params:
+        num_negatives: 32000
+        type: random
+      memory_params:
+        memory_size: -1 # auto_filled as num_train_samples
+        embedding_dim: 128
+        momentum: 0.5
+        norm_init: True
+        update_mem_on_forward: False
+      update_mem_with_emb_index: 1
+      num_train_samples: 1281167
+  OPTIMIZER:
+      num_epochs: 400

--- a/configs/config/pretrain/pirl/pirl_jigsaw_4node_resnet50.yaml
+++ b/configs/config/pretrain/pirl/pirl_jigsaw_4node_resnet50.yaml
@@ -76,7 +76,7 @@ config:
         num_negatives: 32000
         type: random
       memory_params:
-        memory_size: -1
+        memory_size: -1 # auto_filled as num_train_samples
         embedding_dim: 128
         momentum: 0.5
         norm_init: True
@@ -105,7 +105,7 @@ config:
   DISTRIBUTED:
     BACKEND: nccl
     NUM_NODES: 4
-    RUN_ID: xxxxxxxxxxxxxxxx
+    RUN_ID: auto
     NUM_PROC_PER_NODE: 8
     INIT_METHOD: tcp
     NCCL_DEBUG: True
@@ -113,6 +113,6 @@ config:
   MACHINE:
     DEVICE: gpu
   CHECKPOINT:
-    DIR: /mnt/vol/gfsai-bistro2-east/ai-group/users/prigoyal/distributed/
+    DIR: "." 
     AUTO_RESUME: True
     CHECKPOINT_FREQUENCY: 100

--- a/configs/config/pretrain/pirl/transforms/photo_gblur.yaml
+++ b/configs/config/pretrain/pirl/transforms/photo_gblur.yaml
@@ -1,0 +1,32 @@
+# @package _global_
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 8
+    TRAIN:
+      DATA_SOURCES: [disk_folder]
+      DATASET_NAMES: [imagenet1k_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      LABEL_TYPE: sample_index
+      TRANSFORMS:
+        - name: ImgPilToPatchesAndImage
+          crop_scale_image: [0.08, 1.0]   # default PyTorch
+          crop_size_image: 224            # default PyTorch
+          crop_scale_patches: [0.6, 1.0]
+          crop_size_patches: 255          # default Jigsaw
+          num_patches: 9
+        - name: RandomHorizontalFlip
+          p: 0.5
+        - name: ImgPilColorDistortion
+          strength: 1.0
+        - name: ImgPilGaussianBlur
+          p: 0.5
+          radius_min: 0.1
+          radius_max: 2.0
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      COLLATE_FUNCTION: "patch_and_image_collator"
+      INPUT_KEY_NAMES: ["patches", "images"] # keys produced by data that are `inputs' to the model
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False

--- a/vissl/losses/nce_loss.py
+++ b/vissl/losses/nce_loss.py
@@ -122,7 +122,9 @@ class NCELossWithMemory(ClassyLoss):
                 curr_loss = self.nce_criterion(nce_average, target)
             elif self.loss_type == "cross_entropy":
                 labels = torch.zeros(
-                    nce_average.shape[0], device=nce_average.device, dtype=torch.int64
+                    (nce_average.shape[0], 1),
+                    device=nce_average.device,
+                    dtype=torch.int64,
                 )
                 curr_loss = self.xe_criterion(nce_average, labels)
             loss += self.loss_weights[l_idx] * curr_loss


### PR DESCRIPTION
Summary:
**Waiting on R50w4 trainings. Others are finished.**
- Add 200 epoch R50 run
- Add w2 and w4 models for PIRL
- Add MLP head (R50, R50w2, R50w4) for PIRL

Minor bugfix for nce_loss shape.

Differential Revision: D23137423

