### PR TITLE
Fix Apex install on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ cpu: &cpu
 gpu: &gpu
   environment:
     CUDA_VER: "10.2"
+    TORCH_CUDA_ARCH_LIST: "5.0;5.2;5.3"
     TERM: xterm
   machine:
     image: ubuntu-1604:201903-01
@@ -34,6 +35,18 @@ install_python: &install_python
         pyenv install 3.6.1
         pyenv global 3.6.1
 
+update_gcc7: &update_gcc7
+  - run:
+      name: Update GCC7
+      working_directory: ~/
+      command: |
+        sudo apt-get update
+        sudo add-apt-repository ppa:jonathonf/gcc-7.1
+        sudo apt-get update
+        sudo apt-get install gcc-7 g++-7
+        sudo update-alternatives  --install /usr/bin/gcc gcc /usr/bin/gcc-7 60  --slave /usr/bin/g++ g++ /usr/bin/g++-7  --slave /usr/bin/gcov gcov /usr/bin/gcov-7  --slave /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-7  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-7  --slave /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-7  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-7
+        gcc --version
+        g++ --version
 
 install_classy_vision: &install_classy_vision
   - run:
@@ -89,6 +102,7 @@ install_apex_gpu: &install_apex_gpu
       working_directory: ~/vissl
       environment:
         CUDA_VER: "10.2"
+        TORCH_CUDA_ARCH_LIST: "5.0;5.2;5.3"
       command: |
         bash ./docker/common/install_apex.sh
 
@@ -175,6 +189,7 @@ jobs:
 
       - <<: *install_vissl_dep
       - <<: *install_classy_vision
+      - <<: *update_gcc7
       - <<: *install_apex_gpu
       - <<: *pip_list
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,5 +61,6 @@ That's it! You are now ready to use this code.
 Apex installation requires that you have a latest nvcc so the c++ extensions can be compiled with latest gcc (>=7.4). Check the APEX website for more instructions.
 
 ```bash
-CUDA_VER=10.1 ./docker/common/install_apex.sh
+# see https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list to select cuda architecture you want to build
+CUDA_VER=10.1 TORCH_CUDA_ARCH_LIST="5.0;5.2;5.3;6.0;6.1;6.2;7.0;7.5" ./docker/common/install_apex.sh
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN pip install --user torch==1.5 torchvision==0.6 -f https://download.pytorch.o
 
 # install apex
 ARG TORCH_CUDA_ARCH_LIST
+ARG CUDA_VER
 ADD ./common/install_apex.sh install_apex.sh
 RUN bash ./install_apex.sh && rm install_apex.sh
 

--- a/docker/common/install_apex.sh
+++ b/docker/common/install_apex.sh
@@ -15,7 +15,8 @@ nvcc --version
 
 # see https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list
 # maxwell, pascal, volta
-export TORCH_CUDA_ARCH_LIST="5.0;5.2;5.3;6.0;6.1;6.2;7.0;7.5"
+# example: TORCH_CUDA_ARCH_LIST="5.0;5.2;5.3;6.0;6.1;6.2;7.0;7.5"
+export TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
 
 # install apex now (note that we recommend a specific apex version for stability)
 pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" apex@https://github.com/NVIDIA/apex/tarball/1f2aa9156547377a023932a1512752c392d9bbdf

--- a/docker/conda/Dockerfile
+++ b/docker/conda/Dockerfile
@@ -29,6 +29,7 @@ RUN conda install pytorch torchvision cudatoolkit=${CUDA_VER} -c pytorch
 
 # install apex
 ARG TORCH_CUDA_ARCH_LIST
+ARG CUDA_VER
 ADD ./common/install_apex.sh install_apex.sh
 RUN bash ./install_apex.sh && rm install_apex.sh
 


### PR DESCRIPTION
Summary: apex is currently failing to build on circleCI. after much debugging, figured out that this is due to gcc version. Fixing that. tested with ssh but will also wait to see greenlight on circleci before this diff can land

Reviewed By: mannatsingh

Differential Revision: D23223557

