### PR TITLE
CPU Tests should not autoresume from checkpoints

### DIFF
--- a/configs/config/test/cpu_test/test_cpu_efficientnet_simclr.yaml
+++ b/configs/config/test/cpu_test/test_cpu_efficientnet_simclr.yaml
@@ -108,6 +108,6 @@ config:
     DEVICE: cpu
   CHECKPOINT:
     DIR: "."
-    AUTO_RESUME: True
+    AUTO_RESUME: false
     CHECKPOINT_FREQUENCY: 5
     OVERWRITE_EXISTING: true

--- a/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
+++ b/configs/config/test/cpu_test/test_cpu_regnet_simclr.yaml
@@ -108,6 +108,6 @@ config:
     DEVICE: cpu
   CHECKPOINT:
     DIR: "."
-    AUTO_RESUME: True
+    AUTO_RESUME: false
     CHECKPOINT_FREQUENCY: 5
     OVERWRITE_EXISTING: true

--- a/configs/config/test/cpu_test/test_cpu_resnet_simclr.yaml
+++ b/configs/config/test/cpu_test/test_cpu_resnet_simclr.yaml
@@ -100,6 +100,6 @@ config:
     DEVICE: cpu
   CHECKPOINT:
     DIR: "."
-    AUTO_RESUME: True
+    AUTO_RESUME: false
     CHECKPOINT_FREQUENCY: 5
     OVERWRITE_EXISTING: true


### PR DESCRIPTION
Summary: On circleci it seems that some tests are run on the same machine, leading to the next test in line leading the previous one's checkpoint. This breaks if the model differs in between the two tests. Another option could be to define test-specific dir checkpoints, but having read/write rights across CI systems could be an issue

Differential Revision: D23475734

