### PR TITLE
activation checkpointing and manual gradient reduction

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -524,6 +524,8 @@ config:
     #      - If using 1 machine, set RUN_ID=auto and a free port will be automatically selected
     #   3. IF using INIT_METHOD=file, RUN_ID={file_path}
     RUN_ID: "auto"
+    # if True, does the gradient reduction in DDP
+    MANUAL_GRADIENT_REDUCTION: False
 
   # ----------------------------------------------------------------------------------- #
   # SVM (benchmark)

--- a/vissl/trainer/train_task.py
+++ b/vissl/trainer/train_task.py
@@ -530,3 +530,13 @@ class SelfSupervisionTask(ClassificationTask):
         if self.device.type == "cuda":
             self.base_model = copy_model_to_gpu(self.base_model)
         return self
+
+    def manual_gradient_reduction(self) -> bool:
+        """
+        Return if we should use manual gradient reduction or not.
+
+        We should use manual DDP if config says so and model is wrapped by DDP.
+        """
+        return self.config["DISTRIBUTED"]["MANUAL_GRADIENT_REDUCTION"] and hasattr(
+            self.model, "no_sync"
+        )


### PR DESCRIPTION
Summary:
[VISSL] activation checkpointing and manual gradient reduction

- This change builds on top of Benjamin's change so that we have better
  activitation checkpointing support.
- This change adds a config option where we can use manual gradient reduction
  to avoid checkpointing & DDP issues.
- Note two things about splitting
  . depends on how many user want to split, we can split until it is not splitable any more from the trunk
  . we need to keep in-place-relu to be together with its previous layer since in-place op & checkpointing doesn't jive
  . memory and btime from different splits are interesting (see test plan)

Differential Revision: D24230961

