### PR TITLE
remove python37 feature only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = True
 lines_after_imports = 2
-known_third_party = PIL,bs4,classy_vision,cv2,detectron2,run_distributed_engines,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
+known_third_party = PIL,bs4,classy_vision,cv2,detectron2,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,run_distributed_engines,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
 skip_glob = build/*,third-party/*,.github/*

--- a/vissl/trainer/train_steps/standard_train_step.py
+++ b/vissl/trainer/train_steps/standard_train_step.py
@@ -4,7 +4,7 @@
 This is the train step that"s most commonly used in most of the model trainings.
 """
 
-import contextlib
+# import contextlib
 from types import SimpleNamespace
 
 import torch
@@ -97,12 +97,12 @@ def standard_train_step(task):
 
     # Only need gradients during training
     grad_context = torch.enable_grad() if task.train else torch.no_grad()
-    ddp_context = (
-        task.model.no_sync()
-        if task.enable_manual_gradient_reduction
-        else contextlib.nullcontext()
-    )
-    with grad_context, ddp_context:
+    # ddp_context = (
+    #    task.model.no_sync()
+    #    if task.enable_manual_gradient_reduction
+    #    else contextlib.nullcontext()
+    # )
+    with grad_context:
         # Forward pass of the model
         with PerfTimer("forward", perf_stats):
             if task.enable_manual_gradient_reduction:


### PR DESCRIPTION
the contextlib.nocontext() is a python3.7+ feature and we support python3.6+  in vissl. @min-xu-ai to find alternative for this. in the meantime creating this PR to unblock .