### PR TITLE
Fix vissl GPU circleCI tests with gcc7 install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ update_gcc7: &update_gcc7
       working_directory: ~/
       command: |
         sudo apt-get update
-        sudo add-apt-repository ppa:jonathonf/gcc-7.1
+        sudo add-apt-repository ppa:jonathonf/gcc
         sudo apt-get update
         sudo apt-get install gcc-7 g++-7
         sudo update-alternatives  --install /usr/bin/gcc gcc /usr/bin/gcc-7 60  --slave /usr/bin/g++ g++ /usr/bin/g++-7  --slave /usr/bin/gcov gcov /usr/bin/gcov-7  --slave /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-7  --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-7  --slave /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-7  --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-7


### PR DESCRIPTION
Summary: gcc7 ppa is not found. make it non-version specific as suggested by growlix :)

Differential Revision: D25542412

