### PR TITLE
Updated homepage footer from generic template

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -55,7 +55,7 @@ const siteConfig = {
 
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
-  copyright: `Copyright \u{00A9} ${new Date().getFullYear()} Your Name or Your Company Name`,
+  copyright: `Copyright \u{00A9} ${new Date().getFullYear()} Facebook Inc.`,
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.


### PR DESCRIPTION
Updated homepage footer to say "Copyright © 2021 Facebook Inc." instead of "Copyright © 2021 Your Name or Your Company Name"