### PR TITLE
Hydra plugin now allow to search the configuration in the current path.

### DIFF
--- a/hydra_plugins/vissl_plugin/vissl_plugin.py
+++ b/hydra_plugins/vissl_plugin/vissl_plugin.py
@@ -7,3 +7,4 @@ from hydra.plugins.search_path_plugin import SearchPathPlugin
 class VisslPlugin(SearchPathPlugin):
     def manipulate_search_path(self, search_path: ConfigSearchPath) -> None:
         search_path.prepend(provider="vissl", path="pkg://configs")
+        search_path.prepend(provider="vissl", path="file://configs")


### PR DESCRIPTION
This is useful in the following test case: running VISSL from another directory on which some configurations are stored separately from the VISSL repository (for instance, in order to create configurations that should not end up being committed in VISSL by mistake, or configurations that are specific to another client repository).