### PR TITLE
[fix] missing import referenced in __all__ of "vissl.data"

### DIFF
--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader
 from vissl.data.collators import get_collator
 from vissl.data.data_helper import StatefulDistributedSampler
 from vissl.data.dataloader_sync_gpu_wrapper import DataloaderSyncGPUWrapper
-from vissl.data.dataset_catalog import VisslDatasetCatalog, register_datasets
+from vissl.data.dataset_catalog import VisslDatasetCatalog, register_datasets, get_data_files
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -5,10 +5,15 @@ import logging
 import torch
 from classy_vision.dataset import DataloaderAsyncGPUWrapper
 from torch.utils.data import DataLoader
+
 from vissl.data.collators import get_collator
 from vissl.data.data_helper import StatefulDistributedSampler
 from vissl.data.dataloader_sync_gpu_wrapper import DataloaderSyncGPUWrapper
-from vissl.data.dataset_catalog import VisslDatasetCatalog, register_datasets, get_data_files
+from vissl.data.dataset_catalog import (
+    VisslDatasetCatalog,
+    get_data_files,
+    register_datasets,
+)
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset


### PR DESCRIPTION
The function `get_data_files`  is referenced in `__all__`, but is not part of the imports above. The two valid choices are either to remove it from `__all__` or to import it. I thought the second option made more sense here but I might be wrong.