### PR TITLE
First draft for enriching the datasets of VISSL with Pytorch dataset that do not follow the "disk_folder" layout.

### DIFF
--- a/configs/config/benchmark/linear_image_classification/cifar/eval_resnet_8gpu_transfer_cifar10.yaml
+++ b/configs/config/benchmark/linear_image_classification/cifar/eval_resnet_8gpu_transfer_cifar10.yaml
@@ -1,0 +1,115 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 1
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [CIFAR10]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+    TEST:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [CIFAR10]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_ONLY: True
+      SHOULD_FLATTEN_FEATS: False
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 1000]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: apex
+      GROUP_SIZE: 8
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+      name: sgd
+      weight_decay: 0.001
+      momentum: 0.9
+      num_epochs: 200
+      nesterov: True
+      regularize_bn: False
+      regularize_bias: True
+      use_larc: False
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.01
+            base_lr_batch_size: 256
+
+          # Multi-step LR
+          name: multistep
+          values: [0.01, 0.001, 0.0001]
+          milestones: [70, 140]
+
+          # Cosine schedule (seems to work better)
+          # name: cosine
+          # start_value: 0.01
+          # end_value: 0.0001
+
+          update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/benchmark/linear_image_classification/cifar/eval_resnet_8gpu_transfer_cifar100.yaml
+++ b/configs/config/benchmark/linear_image_classification/cifar/eval_resnet_8gpu_transfer_cifar100.yaml
@@ -1,0 +1,115 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 1
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [CIFAR100]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+    TEST:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [CIFAR100]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1, 5]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_ONLY: True
+      SHOULD_FLATTEN_FEATS: False
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 1000]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: apex
+      GROUP_SIZE: 8
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+      name: sgd
+      weight_decay: 0.001
+      momentum: 0.9
+      num_epochs: 200
+      nesterov: True
+      regularize_bn: False
+      regularize_bias: True
+      use_larc: False
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.01
+            base_lr_batch_size: 256
+
+          # Multi-step LR
+          name: multistep
+          values: [0.01, 0.001, 0.0001]
+          milestones: [70, 140]
+
+          # Cosine schedule (seems to work better)
+          # name: cosine
+          # start_value: 0.01
+          # end_value: 0.0001
+
+          update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/benchmark/linear_image_classification/stl10/eval_resnet_8gpu_transfer_stl10.yaml
+++ b/configs/config/benchmark/linear_image_classification/stl10/eval_resnet_8gpu_transfer_stl10.yaml
@@ -1,0 +1,113 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 1
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [STL10]
+      BATCHSIZE_PER_REPLICA: 128
+      TRANSFORMS:
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+    TEST:
+      DATA_SOURCES: [pytorch_dataset]
+      LABEL_SOURCES: [pytorch_dataset]
+      DATASET_NAMES: [STL10]
+      BATCHSIZE_PER_REPLICA: 128
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_ONLY: True
+      SHOULD_FLATTEN_FEATS: False
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 1000]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: apex
+      GROUP_SIZE: 8
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+      name: sgd
+      weight_decay: 0.001
+      momentum: 0.9
+      num_epochs: 200
+      nesterov: True
+      regularize_bn: False
+      regularize_bias: True
+      use_larc: False
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.01
+            base_lr_batch_size: 256
+
+          # Multi-step LR
+          # name: multistep
+          # values: [0.01, 0.001, 0.0001]
+          # milestones: [70, 140]
+
+          # Cosine schedule (seems to work better)
+          name: cosine
+          start_value: 0.01
+          end_value: 0.0001
+
+          update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -19,6 +19,10 @@
         "train": ["<path_to_pytorch_folder>", "<lbl_path>"],
         "val": ["<path_to_pytorch_folder>", "<lbl_path>"]
     },
+    "STL10": {
+        "train": ["<path_to_pytorch_folder>", "<lbl_path>"],
+        "val": ["<path_to_pytorch_folder>", "<lbl_path>"]
+    },
     "inaturalist2018_folder": {
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]

--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -11,6 +11,14 @@
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]
     },
+    "CIFAR10": {
+        "train": ["<path_to_pytorch_folder>", "<lbl_path>"],
+        "val": ["<path_to_pytorch_folder>", "<lbl_path>"]
+    },
+    "CIFAR100": {
+        "train": ["<path_to_pytorch_folder>", "<lbl_path>"],
+        "val": ["<path_to_pytorch_folder>", "<lbl_path>"]
+    },
     "inaturalist2018_folder": {
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -12,6 +12,7 @@ from vissl.data.dataset_catalog import VisslDatasetCatalog, register_datasets
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset
+from vissl.data.torchvision_dataset import PytorchImageDataset
 from vissl.utils.misc import setup_multiprocessing_method
 
 
@@ -25,6 +26,7 @@ __all__ = [
 DATASET_SOURCE_MAP = {
     "disk_filelist": DiskImageDataset,
     "disk_folder": DiskImageDataset,
+    "pytorch_dataset": PytorchImageDataset,
     "synthetic": SyntheticImageDataset,
 }
 

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -200,6 +200,12 @@ class GenericSSLDataset(Dataset):
                 # We do not create it again since it can be an expensive operation.
                 labels = [x[1] for x in self.data_objs[idx].image_dataset.samples]
                 labels = np.array(labels).astype(np.int64)
+            elif label_source == "pytorch_dataset":
+                labels = [
+                    self.data_objs[idx].get_image_and_label(i)[1]
+                    for i in range(len(self.data_objs[idx]))
+                ]
+                labels = np.array(labels).astype(np.int64)
             else:
                 raise ValueError(f"unknown label source: {label_source}")
             self.label_objs.append(labels)

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from PIL import Image
 from fvcore.common.file_io import PathManager
 from torch.utils.data import Dataset
-from torchvision.datasets import CIFAR10, CIFAR100
+from torchvision.datasets import CIFAR10, CIFAR100, STL10
 
 from vissl.utils.hydra_config import AttrDict
 
@@ -40,6 +40,9 @@ class PytorchImageDataset(Dataset):
             return CIFAR10(self.path, train=self.split == "train")
         elif self.dataset_name == "CIFAR100":
             return CIFAR100(self.path, train=self.split == "train")
+        elif self.dataset_name == "STL10":
+            stl_split = "train" if self.split == "train" else "test"
+            return STL10(self.path, split=stl_split)
         else:
             raise ValueError(f"Unsupported dataset {self.dataset_name: str}")
 

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -1,0 +1,70 @@
+from typing import Tuple
+
+from PIL import Image
+from fvcore.common.file_io import PathManager
+from torch.utils.data import Dataset
+from torchvision.datasets import CIFAR10, CIFAR100
+
+from vissl.utils.hydra_config import AttrDict
+
+
+class PytorchImageDataset(Dataset):
+    """
+    Adapter dataset to available datasets in Torchvision.
+    The selected dataset is based on the name provided as argument.
+    This name must match the names of the dataset in torchvision.
+
+    Args:
+        cfg (AttrDict): configuration defined by user
+        data_source (string): data source ("pytorch_dataset") [not used]
+        path (string): path to the dataset
+        split (string): specify split for the dataset (either "train" or "val").
+        dataset_name (string): name of dataset.
+    """
+
+    def __init__(self,
+                 cfg: AttrDict,
+                 data_source: str,
+                 path: str,
+                 split: str,
+                 dataset_name: str):
+        super().__init__()
+        assert PathManager.isdir(path), f"Directory {path} does not exist"
+        self.dataset_name = dataset_name
+        self.path = path
+        self.split = split.lower()
+        self.dataset = self._load_dataset()
+
+    def _load_dataset(self):
+        if self.dataset_name == "CIFAR10":
+            return CIFAR10(self.path, train=self.split == "train")
+        elif self.dataset_name == "CIFAR100":
+            return CIFAR100(self.path, train=self.split == "train")
+        else:
+            raise ValueError(f"Unsupported dataset {self.dataset_name: str}")
+
+    def num_samples(self) -> int:
+        """
+        Size of the dataset
+        """
+        return len(self.dataset)
+
+    def __len__(self) -> int:
+        """
+        Size of the dataset
+        """
+        return self.num_samples()
+
+    def __getitem__(self, idx: int) -> Tuple[Image.Image, bool]:
+        """
+        Return the image at index 'idx' and whether the load was successful
+        Note: we do delayed loading of data to reduce the memory size
+              due to pickling of dataset across dataloader workers.
+        """
+        image = self.dataset[idx][0]
+        is_success = True
+        return image, is_success
+
+    def get_image_and_label(self, idx: int) -> Tuple[Image.Image, int]:
+        sample = self.dataset[idx]
+        return sample[0], sample[1]


### PR DESCRIPTION
This PR is a first draft to discuss the approach to integrate these datasets:
- is the "pytorch_dataset" a good idea for integrating (knowing that there might be overlaps, like "Imagenet" or "Places365")
- the hyper-parameters of the linear evaluation on both CIFAR10 and CIFAR100 are not tuned
- more datasets could be integrated this way: for instance MNIST (which is used as benchmark in the CLIP paper) but with modifications (we would have to wrap it to return images with 3 channels instead of 1 and of size 32)