### PR TITLE
[feature] Add a script to create a image classification dataset from UCF101 and example configuration

### DIFF
--- a/configs/config/benchmark/linear_image_classification/ucf101/eval_resnet_8gpu_transfer_ucf101.yaml
+++ b/configs/config/benchmark/linear_image_classification/ucf101/eval_resnet_8gpu_transfer_ucf101.yaml
@@ -93,17 +93,9 @@ config:
             auto_scale: true
             base_value: 0.01
             base_lr_batch_size: 256
-
-          # Multi-step LR
           name: multistep
           values: [0.01, 0.001, 0.0001]
           milestones: [70, 140]
-
-          # Cosine schedule (seems to work better)
-          # name: cosine
-          # start_value: 0.01
-          # end_value: 0.0001
-
           update_interval: epoch
   DISTRIBUTED:
     BACKEND: nccl

--- a/configs/config/benchmark/linear_image_classification/ucf101/eval_resnet_8gpu_transfer_ucf101.yaml
+++ b/configs/config/benchmark/linear_image_classification/ucf101/eval_resnet_8gpu_transfer_ucf101.yaml
@@ -1,0 +1,119 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 1
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [disk_folder]
+      LABEL_SOURCES: [disk_folder]
+      DATASET_NAMES: [ucf101_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 224
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/ucf101_folder/
+    TEST:
+      DATA_SOURCES: [disk_folder]
+      LABEL_SOURCES: [disk_folder]
+      DATASET_NAMES: [ucf101_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: 256
+        - name: CenterCrop
+          size: 224
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/ucf101_folder/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_ONLY: True
+      SHOULD_FLATTEN_FEATS: False
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 1000]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: apex
+      GROUP_SIZE: 8
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+      name: sgd
+      weight_decay: 0.001
+      momentum: 0.9
+      num_epochs: 200
+      nesterov: True
+      regularize_bn: False
+      regularize_bias: True
+      use_larc: False
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.01
+            base_lr_batch_size: 256
+
+          # Multi-step LR
+          name: multistep
+          values: [0.01, 0.001, 0.0001]
+          milestones: [70, 140]
+
+          # Cosine schedule (seems to work better)
+          # name: cosine
+          # start_value: 0.01
+          # end_value: 0.0001
+
+          update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -19,6 +19,10 @@
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]
     },
+    "ucf101_folder": {
+        "train": ["<img_path>", "<lbl_path>"],
+        "val": ["<img_path>", "<lbl_path>"]
+    },
     "voc2007_folder": {
         "train": ["<root_folder>", "<root_folder>"],
         "val": ["<root_folder>", "<root_folder>"]

--- a/extra_scripts/create_ucf101_data_files.py
+++ b/extra_scripts/create_ucf101_data_files.py
@@ -111,6 +111,12 @@ if __name__ == '__main__':
         -a /datasets01/ucf101/112018/ucfTrainTestlist/testlist01.txt \
         -o /checkpoint/qduval/vissl/ucf101/test
     ```
+    
+    Each of the artifacts pointed by the script correspond to elements which can be downloaded
+    directly from the webside of UCF101: https://www.crcv.ucf.edu/data/UCF101.php.
+    - the data corresponds to the videos (https://www.crcv.ucf.edu/data/UCF101/UCF101.rar)
+    - the annotations corresponds to one of the action recognition train/test split file
+      (https://www.crcv.ucf.edu/data/UCF101/UCF101TrainTestSplits-RecognitionTask.zip)
     """
     args = get_argument_parser().parse_args()
     create_disk_folder(

--- a/extra_scripts/create_ucf101_data_files.py
+++ b/extra_scripts/create_ucf101_data_files.py
@@ -1,0 +1,122 @@
+import argparse
+import os
+from typing import Optional, List, Tuple
+
+from PIL import Image
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+try:
+    import av
+except ImportError:
+    raise ValueError("You must have pyav installed to run this script: pip install av.")
+
+
+def extract_mid_frame(file_path: str) -> Optional[Image.Image]:
+    """
+    Extract the middle frame out of a video clip.
+    """
+    with av.open(file_path) as container:
+        nb_frames = container.streams.video[0].frames
+        vid_stream = container.streams.video[0]
+        for i, frame in enumerate(container.decode(vid_stream)):
+            if i - 1 == nb_frames // 2:
+                return frame.to_image()
+        return None
+
+
+def extract_split_info(file_path: str) -> List[Tuple[str, str]]:
+    """
+    Parse an annotation file of ucf101 and list the samples, grouped by category
+    """
+    samples = []
+    with open(file_path) as f:
+        for line in f:
+            category, file_name = line.strip().split("/")
+            file_name = file_name.split(" ")[0]
+            samples.append((category, file_name))
+    return samples
+
+
+class _ExtractMiddleFrameDataset:
+    """
+    Dataset used to parallelize the reading of of the middle frame by using a pytorch DataLoader
+    """
+    def __init__(self, data_path: str, annotation_path: str):
+        self.data_path = data_path
+        self.split_info = extract_split_info(annotation_path)
+
+    def __len__(self):
+        return len(self.split_info)
+
+    def __getitem__(self, idx: int) -> Tuple[Image.Image, str, str]:
+        category, video_name = self.split_info[idx]
+        video_path = os.path.join(self.data_path, video_name)
+        mid_frame = extract_mid_frame(video_path)
+        image_name = os.path.splitext(video_name)[0] + ".jpg"
+        return mid_frame, image_name, category
+
+
+def create_disk_folder(
+    annotation_path: str,
+    data_path: str,
+    output_path: str,
+    num_workers: int,
+):
+    """
+    Read the annotation path, extract from it the split information, and create a folder with the following structure:
+
+        Action1/
+            Image1
+            ...
+        Action2/
+            Image2
+            ...
+    """
+    assert os.path.exists(annotation_path), f"Could not find annotation path {annotation_path}"
+    assert os.path.exists(data_path), f"Could not find data folder {data_path}"
+
+    dataset = _ExtractMiddleFrameDataset(data_path=data_path, annotation_path=annotation_path)
+    loader = DataLoader(dataset, num_workers=num_workers, batch_size=1, collate_fn=lambda x: x[0])
+    for batch in tqdm(loader):
+        mid_frame, image_name, category = batch
+        category_folder = os.path.join(output_path, category)
+        os.makedirs(category_folder, exist_ok=True)
+        image_path = os.path.join(category_folder, image_name)
+        with open(image_path, "w") as image_file:
+            mid_frame.save(image_file)
+
+
+def get_argument_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--data', type=str, help="Data path")
+    parser.add_argument('-a', '--annotation', type=str, help="File annotation path")
+    parser.add_argument('-o', '--output', type=str, help="Output folder")
+    parser.add_argument('-w', '--workers', type=int, default=8, help="Number of parallel workers")
+    return parser
+
+
+if __name__ == '__main__':
+    """
+    Example usage:
+    
+    ```
+    python extra_scripts/create_ucf101_data_files.py \
+        -d /datasets01/ucf101/112018/data \
+        -a /datasets01/ucf101/112018/ucfTrainTestlist/trainlist01.txt \
+        -o /checkpoint/qduval/vissl/ucf101/train
+    
+    python extra_scripts/create_ucf101_data_files.py \
+        -d /datasets01/ucf101/112018/data \
+        -a /datasets01/ucf101/112018/ucfTrainTestlist/testlist01.txt \
+        -o /checkpoint/qduval/vissl/ucf101/test
+    ```
+    """
+    args = get_argument_parser().parse_args()
+    create_disk_folder(
+        annotation_path=args.annotation,
+        data_path=args.data,
+        output_path=args.output,
+        num_workers=args.workers
+    )
+


### PR DESCRIPTION
Add a script to create a image classification dataset from UCF101, the way it is described in the CLIP paper from OpenAI (https://cdn.openai.com/papers/Learning_Transferable_Visual_Models_From_Natural_Language_Supervision.pdf):

The script takes as inputs artefacts which can be downloaded directly from the web side of the dataset (https://www.crcv.ucf.edu/data/UCF101.php, which is also equivalent to the content expected by torchvision) and can be executed as follows:

```
python extra_scripts/create_ucf101_data_files.py \
    -d /datasets01/ucf101/112018/data \
    -a /datasets01/ucf101/112018/ucfTrainTestlist/trainlist01.txt \
    -o /checkpoint/qduval/vissl/ucf101/train

python extra_scripts/create_ucf101_data_files.py \
    -d /datasets01/ucf101/112018/data \
    -a /datasets01/ucf101/112018/ucfTrainTestlist/testlist01.txt \
    -o /checkpoint/qduval/vissl/ucf101/test
```

The output of the script is compatible with the "disk_folder" and can be fed into the normal linear_image_classification benchmark workflow. Each sample of this new dataset is created as follows:
- the middle frame of the video is taken (to be fed in the classifier)
- the target action is used as label (as target of the classifier)

The script is multi-threaded (several videos will be handled in parallel) and should take just a few minutes to complete.