### PR TITLE
Adding a hook to profile memory usage

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -84,6 +84,21 @@ config:
   LOG_GPU_STATS: True
 
   # ----------------------------------------------------------------------------------- #
+  # HOOKS
+  # ----------------------------------------------------------------------------------- #
+  HOOKS:
+    # ----------------------------------------------------------------------------------- #
+    # torch.cuda.memory_summary()
+    # ----------------------------------------------------------------------------------- #
+    MEMORY_SUMMARY:
+      # set this to true if you want to print memory summary. useful for profiling
+      # memory consumption of model
+      PRINT_MEMORY_SUMMARY: False
+      # at what iteration number should the memory summary be printed. usually
+      # set to 1 for very large models
+      LOG_ITERATION_NUM: 0
+
+  # ----------------------------------------------------------------------------------- #
   # DATA
   # ----------------------------------------------------------------------------------- #
   DATA:

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -537,7 +537,7 @@ config:
       num_prototypes: [3000]        # automatically inferred from model HEAD settings
       temp_hard_assignment_iters: 0
       # for dumping the debugging info in case loss becomes NaN
-      output_dir: ""                # automatically inferred and set to checkpoint dir
+      output_dir: "."               # automatically inferred and set to checkpoint dir
       queue:
         queue_length: 0             # automatically adjusted to ensure queue_length % global batch size = 0
         start_iter: 0
@@ -593,6 +593,8 @@ config:
   # ----------------------------------------------------------------------------------- #
   OPTIMIZER:
     name: "sgd"
+    # whether to shard optimizer state as per ZeRO https://arxiv.org/abs/1910.02054
+    use_zero: False
     use_larc: False  # supported for SGD only for now
     larc_config:
       clip: False

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -258,6 +258,9 @@ config:
       # how many times the model should be checkpointed. User should tune this parameter
       # and find the number that offers best memory saving and compute tradeoff.
       NUM_ACTIVATION_CHECKPOINTING_SPLITS: 2
+    # setup for Fairscale sharded DDP
+    SHARDED_DDP_SETUP:
+      reduce_buffer_size: -1
     # ----------------------------------------------------------------------------------- #
     # Feature evaluation settings
     # ----------------------------------------------------------------------------------- #

--- a/vissl/hooks/__init__.py
+++ b/vissl/hooks/__init__.py
@@ -7,6 +7,7 @@ from classy_vision.hooks.classy_hook import ClassyHook
 from vissl.hooks.deepclusterv2_hooks import ClusterMemoryHook, InitMemoryHook  # noqa
 from vissl.hooks.log_hooks import (  # noqa
     LogGpuStatsHook,
+    LogGpuMemoryHook,
     LogLossLrEtaHook,
     LogLossMetricsCheckpointHook,
     LogPerfTimeMetricsHook,
@@ -100,6 +101,8 @@ def default_hook_generator(cfg: AttrDict) -> List[ClassyHook]:
         hooks.extend([SSLModelComplexityHook()])
     if cfg.LOG_GPU_STATS:
         hooks.extend([LogGpuStatsHook()])
+    if cfg.HOOKS.MEMORY_SUMMARY.PRINT_MEMORY_SUMMARY:
+        hooks.extend([LogGpuMemoryHook(cfg.HOOKS.MEMORY_SUMMARY.LOG_ITERATION_NUM)])
     if cfg.TENSORBOARD_SETUP.USE_TENSORBOARD:
         assert is_tensorboard_available(), "Tensorboard must be installed to use it."
         tb_hook = get_tensorboard_hook(cfg)

--- a/vissl/hooks/state_update_hooks.py
+++ b/vissl/hooks/state_update_hooks.py
@@ -260,6 +260,18 @@ class FreezeParametersHook(ClassyHook):
         map_params_to_iters = {}
         for to_map in task.config.MODEL.TEMP_FROZEN_PARAMS_ITER_MAP:
             map_params_to_iters[to_map[0]] = to_map[1]
+
+        # get the maximum iterations until which the params are frozen.
+        # if the iterations are past the maximum iterations freezing any
+        # param, we simply return.
+        max_iterations = max(list(map_params_to_iters.values()))
+        if task.iteration >= max_iterations:
+            if task.iteration == max_iterations:
+                logging.info(
+                    f"No parameters grad removed from now on: {task.iteration}"
+                )
+            return
+
         for name, p in task.model.named_parameters():
             if (
                 name in map_params_to_iters

--- a/vissl/utils/checkpoint.py
+++ b/vissl/utils/checkpoint.py
@@ -45,7 +45,7 @@ def get_checkpoint_folder(config: AttrDict):
     makedir(odir)
     assert PathManager.exists(
         config.CHECKPOINT.DIR
-    ), "Please specify config.CHECKPOINT.DIR parameter. It should not be None."
+    ), f"Please specify config.CHECKPOINT.DIR parameter. Invalid: {config.CHECKPOINT.DIR}"
     return odir
 
 


### PR DESCRIPTION
Summary: recently nvidia-smi was removed from fb cluster making it hard to see what the memory utilization was. using pytorch, we extract the information at various steps of training. the profiling hook is currently experimental and we will use it and adapt it for more better usability. down the line, we can move it to classy vision when the hook is trusted to be useful + changed accordingly

Differential Revision: D26284304

