### PR TITLE
Explore ShardedDDP reduce_buffer_size setting to config

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -537,7 +537,7 @@ config:
       num_prototypes: [3000]        # automatically inferred from model HEAD settings
       temp_hard_assignment_iters: 0
       # for dumping the debugging info in case loss becomes NaN
-      output_dir: ""                # automatically inferred and set to checkpoint dir
+      output_dir: "."               # automatically inferred and set to checkpoint dir
       queue:
         queue_length: 0             # automatically adjusted to ensure queue_length % global batch size = 0
         start_iter: 0
@@ -593,6 +593,8 @@ config:
   # ----------------------------------------------------------------------------------- #
   OPTIMIZER:
     name: "sgd"
+    # whether to shard optimizer state as per ZeRO https://arxiv.org/abs/1910.02054
+    use_zero: False
     use_larc: False  # supported for SGD only for now
     larc_config:
       clip: False

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -258,6 +258,9 @@ config:
       # how many times the model should be checkpointed. User should tune this parameter
       # and find the number that offers best memory saving and compute tradeoff.
       NUM_ACTIVATION_CHECKPOINTING_SPLITS: 2
+    # setup for Fairscale sharded DDP
+    SHARDED_DDP_SETUP:
+      reduce_buffer_size: -1
     # ----------------------------------------------------------------------------------- #
     # Feature evaluation settings
     # ----------------------------------------------------------------------------------- #

--- a/vissl/utils/checkpoint.py
+++ b/vissl/utils/checkpoint.py
@@ -45,7 +45,7 @@ def get_checkpoint_folder(config: AttrDict):
     makedir(odir)
     assert PathManager.exists(
         config.CHECKPOINT.DIR
-    ), "Please specify config.CHECKPOINT.DIR parameter. It should not be None."
+    ), f"Please specify config.CHECKPOINT.DIR parameter. Invalid: {config.CHECKPOINT.DIR}"
     return odir
 
 


### PR DESCRIPTION
Summary: as title, in VISSL, we need to set the `reduce_buffer_size=0`  as there are parameters that are not actually being used and `find_used_parameters` is something not handled by shardedDPP. setting buffer size to 0 will all reduce the gradients immediately instead of bucketing them

Differential Revision: D26276800

