### PR TITLE
Support for torchvision datasets in VISSL (take 2)

### DIFF
--- a/configs/config/benchmark/linear_image_classification/datasets/cifar10.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/cifar10.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 4
+    TRAIN:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [CIFAR10]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+    TEST:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [CIFAR10]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar10/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 10]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/datasets/cifar100.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/cifar100.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 4
+    TRAIN:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [CIFAR100]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar100/
+    TEST:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [CIFAR100]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/cifar100/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1, 5]
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 100]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
@@ -8,7 +8,7 @@ config:
       DATASET_NAMES: [MNIST]
       BATCHSIZE_PER_REPLICA: 256
       TRANSFORMS:
-        - name: ImgPil2RGB
+        - name: MNISTImgPil2RGB
           size: 32
           box: [2, 2]
         - name: RandomResizedCrop
@@ -27,7 +27,7 @@ config:
       DATASET_NAMES: [MNIST]
       BATCHSIZE_PER_REPLICA: 256
       TRANSFORMS:
-        - name: ImgPil2RGB
+        - name: MNISTImgPil2RGB
           size: 32
           box: [2, 2]
         - name: ToTensor

--- a/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
@@ -1,0 +1,47 @@
+# @package _global_
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 4
+    TRAIN:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [MNIST]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/mnist/
+    TEST:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [MNIST]
+      BATCHSIZE_PER_REPLICA: 256
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/mnist/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 10]}],
+      ]

--- a/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/mnist.yaml
@@ -8,6 +8,9 @@ config:
       DATASET_NAMES: [MNIST]
       BATCHSIZE_PER_REPLICA: 256
       TRANSFORMS:
+        - name: ImgPil2RGB
+          size: 32
+          box: [2, 2]
         - name: RandomResizedCrop
           size: 32
         - name: RandomHorizontalFlip
@@ -24,6 +27,9 @@ config:
       DATASET_NAMES: [MNIST]
       BATCHSIZE_PER_REPLICA: 256
       TRANSFORMS:
+        - name: ImgPil2RGB
+          size: 32
+          box: [2, 2]
         - name: ToTensor
         - name: Normalize
           mean: [0.485, 0.456, 0.406]

--- a/configs/config/benchmark/linear_image_classification/datasets/stl10.yaml
+++ b/configs/config/benchmark/linear_image_classification/datasets/stl10.yaml
@@ -1,0 +1,45 @@
+# @package _global_
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 4
+    TRAIN:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [STL10]
+      TRANSFORMS:
+        - name: RandomResizedCrop
+          size: 32
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/stl10/
+    TEST:
+      DATA_SOURCES: [torchvision_dataset]
+      LABEL_SOURCES: [torchvision_dataset]
+      DATASET_NAMES: [STL10]
+      TRANSFORMS:
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/stl10/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1]
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 10]}],
+      ]

--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -15,6 +15,22 @@
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]
     },
+    "CIFAR10": {
+        "train": ["<path_to_pytorch_dataset>", "<unused>"],
+        "val": ["<path_to_pytorch_dataset>", "<unused>"]
+    },
+    "CIFAR100": {
+        "train": ["<path_to_pytorch_dataset>", "<unused>"],
+        "val": ["<path_to_pytorch_dataset>", "<unused>"]
+    },
+    "STL10": {
+        "train": ["<path_to_pytorch_dataset>", "<unused>"],
+        "val": ["<path_to_pytorch_dataset>", "<unused>"]
+    },
+    "MNIST": {
+        "train": ["<path_to_pytorch_dataset>", "<unused>"],
+        "val": ["<path_to_pytorch_dataset>", "<unused>"]
+    },
     "inaturalist2018_folder": {
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]

--- a/docs/source/extend_modules/data_source.rst
+++ b/docs/source/extend_modules/data_source.rst
@@ -68,6 +68,7 @@ VISSL supports data loading from :code:`disk` as the default data source. If use
     DATASET_SOURCE_MAP = {
         "disk_filelist": DiskImageDataset,
         "disk_folder": DiskImageDataset,
+        "torchvision_dataset": TorchvisionDataset,
         "synthetic": SyntheticImageDataset,
         "my_data_source": MyNewSourceDataset,
     }

--- a/docs/source/vissl_modules/data.rst
+++ b/docs/source/vissl_modules/data.rst
@@ -140,8 +140,11 @@ Expected dataset structure for COCO2014
 Expected dataset structure for CIFAR10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
-"CIFAR-10 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html.
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+
+- expanding the "CIFAR-10 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html
+
+- instantiating the :code:`torchvision.datasets.CIFAR10` class with :code:`download=True`
 
 .. code-block::
 
@@ -159,8 +162,11 @@ The expected format is the exact same format used by torchvision, and the exact 
 Expected dataset structure for CIFAR100
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
-"CIFAR-100 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html.*
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+
+- expanding the "CIFAR-100 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html
+
+- instantiating the :code:`torchvision.datasets.CIFAR100` class with :code:`download=True`
 
 .. code-block::
 
@@ -196,8 +202,11 @@ instantiating the :code:`torchvision.datasets.MNIST` class with the flag :code:`
 Expected dataset structure for STL10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
-:code:`stl10_binary.tar.gz` archive available at https://academictorrents.com/details/a799a2845ac29a66c07cf74e2a2838b6c5698a6a.
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+
+- expanding the :code:`stl10_binary.tar.gz` archive available at https://cs.stanford.edu/~acoates/stl10/
+
+- instantiating the :code:`torchvision.datasets.STL10` class with :code:`download=True`
 
 .. code-block::
 

--- a/docs/source/vissl_modules/data.rst
+++ b/docs/source/vissl_modules/data.rst
@@ -11,15 +11,17 @@ To use a dataset in VISSL, the only requirements are:
 Reading data from several sources
 ------------------------------------------
 
-VISSL allows reading data from multiple sources (disk, etc) and in multiple formats (a folder path, a :code:`.npy` file).
+VISSL allows reading data from multiple sources (disk, etc) and in multiple formats (a folder path, a :code:`.npy` file, or torchvision datasets).
 The `GenericSSLDataset <https://github.com/facebookresearch/vissl/blob/master/vissl/data/ssl_dataset.py>`_ class is defined to support reading data from multiple data sources. For example: :code:`data = [dataset1, dataset2]` and the minibatches generated will have the corresponding data from each dataset.
 For this reason, we also support labels from multiple sources. For example :code:`targets = [dataset1 targets, dataset2 targets]`.
 
-Source of the data (:code:`disk_filelist` | :code:`disk_folder`):
+Source of the data (:code:`disk_filelist` | :code:`disk_folder` | :code:`torchvision_dataset`):
 
 - :code:`disk_folder`: this is simply the root folder path to the downloaded data.
 
 - :code:`disk_filelist`: These are numpy (or .pkl) files: (1) file containing images information (2) file containing corresponding labels for images. We provide `scripts <https://github.com/facebookresearch/vissl/blob/master/extra_scripts/README.md>`_ that can be used to prepare these two files for a dataset of choice.
+
+- :code:`torchvision_dataset`: the root folder path to the torchvision dowloaded dataset. As of now, the supported datasets are: CIFAR-10, CIFAR-100, MNIST and STL-10.
 
 To use a dataset, VISSL takes following inputs in the configuration file for each dataset split (train, test):
 
@@ -134,6 +136,79 @@ Expected dataset structure for COCO2014
         val2014/
             # image files that are mentioned in the corresponding json
 
+
+Expected dataset structure for CIFAR10
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
+"CIFAR-10 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html.
+
+.. code-block::
+
+    cifar-10-batches-py/
+        batches.meta
+        data_batch_1
+        data_batch_2
+        data_batch_3
+        data_batch_4
+        data_batch_5
+        readme.html
+        test_batch
+
+
+Expected dataset structure for CIFAR100
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
+"CIFAR-100 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html.*
+
+.. code-block::
+
+    cifar-100-python/
+        meta
+        test
+        train
+
+
+Expected dataset structure for MNIST
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after
+instantiating the :code:`torchvision.datasets.MNIST` class with the flag :code:`download=True`.
+
+.. code-block::
+
+    MNIST/
+        processed/
+            test.pt
+            training.pt
+        raw/
+            t10k-images-idx3-ubyte
+            t10k-images-idx3-ubyte.gz
+            t10k-labels-idx1-ubyte
+            t10k-labels-idx1-ubyte.gz
+            train-images-idx3-ubyte
+            train-images-idx3-ubyte.gz
+            train-labels-idx1-ubyte
+            train-labels-idx1-ubyte.gz
+
+
+Expected dataset structure for STL10
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after expanding the
+:code:`stl10_binary.tar.gz` archive available at https://academictorrents.com/details/a799a2845ac29a66c07cf74e2a2838b6c5698a6a.
+
+.. code-block::
+
+    stl10_binary/
+        class_names.txt
+        fold_indices.txt
+        test_X.bin
+        test_y.bin
+        train_X.bin
+        train_y.bin
+        unlabeled_X.bin
 
 
 Dataloader

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -9,6 +9,7 @@ from torchvision.transforms import Compose, ToTensor
 from vissl.data.ssl_transforms.img_pil_to_tensor import ImgToTensor
 from vissl.data.ssl_transforms.mnist_img_pil_to_rgb_mode import MNISTImgPil2RGB
 
+
 RAND_TENSOR = (torch.rand((224, 224, 3)) * 255).to(dtype=torch.uint8)
 RAND_PIL = Image.fromarray(RAND_TENSOR.numpy())
 RAND_NUMPY = np.asarray(RAND_PIL)
@@ -37,14 +38,19 @@ class TestTransform(unittest.TestCase):
         transform = Compose([MNISTImgPil2RGB.from_config({}), ToTensor()])
         output = transform(one_channel_input)
         assert output.shape == torch.Size([3, 28, 28])
-        assert output.sum().item() == 28 * 28 * 3, "Background should be black, center is gray scale"
+        assert (
+            output.sum().item() == 28 * 28 * 3
+        ), "Background should be black, center is gray scale"
 
         # Test with modifying the image size (try the two valid formats)
         for size in [32, [32, 32]]:
-            transform = Compose([
-                MNISTImgPil2RGB.from_config(dict(size=size, box=[2, 2])),
-                ToTensor()
-            ])
+            transform = Compose(
+                [MNISTImgPil2RGB.from_config({"size": size, "box": [2, 2]}), ToTensor()]
+            )
             output = transform(one_channel_input)
-            assert output.sum().item() == 28 * 28 * 3, "Background should be black, center is gray scale"
-            assert output[:, 2:-2, 2:-2].sum().item() == 28 * 28 * 3, "Paste should be in the middle"
+            assert (
+                output.sum().item() == 28 * 28 * 3
+            ), "Background should be black, center is gray scale"
+            assert (
+                output[:, 2:-2, 2:-2].sum().item() == 28 * 28 * 3
+            ), "Paste should be in the middle"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,7 @@ import torch
 from PIL import Image
 from torchvision.transforms import Compose, ToTensor
 from vissl.data.ssl_transforms.img_pil_to_tensor import ImgToTensor
-from vissl.data.ssl_transforms.img_pil_to_rgb_mode import ImgPil2RGB
+from vissl.data.ssl_transforms.mnist_img_pil_to_rgb_mode import MNISTImgPil2RGB
 
 RAND_TENSOR = (torch.rand((224, 224, 3)) * 255).to(dtype=torch.uint8)
 RAND_PIL = Image.fromarray(RAND_TENSOR.numpy())
@@ -34,7 +34,7 @@ class TestTransform(unittest.TestCase):
         one_channel_input = Image.fromarray(one_channel_input.numpy(), mode="L")
 
         # Test without modifying the image size
-        transform = Compose([ImgPil2RGB.from_config({}), ToTensor()])
+        transform = Compose([MNISTImgPil2RGB.from_config({}), ToTensor()])
         output = transform(one_channel_input)
         assert output.shape == torch.Size([3, 28, 28])
         assert output.sum().item() == 28 * 28 * 3, "Background should be black, center is gray scale"
@@ -42,7 +42,7 @@ class TestTransform(unittest.TestCase):
         # Test with modifying the image size (try the two valid formats)
         for size in [32, [32, 32]]:
             transform = Compose([
-                ImgPil2RGB.from_config(dict(size=size, box=[2, 2])),
+                MNISTImgPil2RGB.from_config(dict(size=size, box=[2, 2])),
                 ToTensor()
             ])
             output = transform(one_channel_input)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -5,9 +5,9 @@ import unittest
 import numpy as np
 import torch
 from PIL import Image
-from torchvision.transforms import ToTensor
+from torchvision.transforms import Compose, ToTensor
 from vissl.data.ssl_transforms.img_pil_to_tensor import ImgToTensor
-
+from vissl.data.ssl_transforms.img_pil_to_rgb_mode import ImgPil2RGB
 
 RAND_TENSOR = (torch.rand((224, 224, 3)) * 255).to(dtype=torch.uint8)
 RAND_PIL = Image.fromarray(RAND_TENSOR.numpy())
@@ -28,3 +28,23 @@ class TestTransform(unittest.TestCase):
         c = ImgToTensor()(RAND_NUMPY)
         d = ToTensor()(RAND_NUMPY)
         self.assertTrue(torch.allclose(c, d))
+
+    def test_img_pil_to_rgb_mode(self):
+        one_channel_input = (torch.ones((28, 28)) * 255).to(dtype=torch.uint8)
+        one_channel_input = Image.fromarray(one_channel_input.numpy(), mode="L")
+
+        # Test without modifying the image size
+        transform = Compose([ImgPil2RGB.from_config({}), ToTensor()])
+        output = transform(one_channel_input)
+        assert output.shape == torch.Size([3, 28, 28])
+        assert output.sum().item() == 28 * 28 * 3, "Background should be black, center is gray scale"
+
+        # Test with modifying the image size (try the two valid formats)
+        for size in [32, [32, 32]]:
+            transform = Compose([
+                ImgPil2RGB.from_config(dict(size=size, box=[2, 2])),
+                ToTensor()
+            ])
+            output = transform(one_channel_input)
+            assert output.sum().item() == 28 * 28 * 3, "Background should be black, center is gray scale"
+            assert output[:, 2:-2, 2:-2].sum().item() == 28 * 28 * 3, "Paste should be in the middle"

--- a/vissl/data/README.md
+++ b/vissl/data/README.md
@@ -57,13 +57,83 @@ coco/
     # image files that are mentioned in the corresponding json
 ```
 
+## Expected dataset structure for CIFAR-10
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+- expanding the "CIFAR-10 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html
+- instantiating the `torchvision.datasets.CIFAR10` class with `download=True`
+
+```
+cifar-10-batches-py/
+    batches.meta
+    data_batch_1
+    data_batch_2
+    data_batch_3
+    data_batch_4
+    data_batch_5
+    readme.html
+    test_batch
+```
+
+## Expected dataset structure for CIFAR-100
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+- expanding the "CIFAR-100 python version" archive available at https://www.cs.toronto.edu/~kriz/cifar.html
+- instantiating the `torchvision.datasets.CIFAR100` class with `download=True`
+
+```
+cifar-100-python/
+    meta
+    test
+    train
+```
+
+## Expected dataset structure for MNIST
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after
+instantiating the `torchvision.datasets.MNIST` class with the flag `download=True`.
+
+```
+MNIST/
+    processed/
+        test.pt
+        training.pt
+    raw/
+        t10k-images-idx3-ubyte
+        t10k-images-idx3-ubyte.gz
+        t10k-labels-idx1-ubyte
+        t10k-labels-idx1-ubyte.gz
+        train-images-idx3-ubyte
+        train-images-idx3-ubyte.gz
+        train-labels-idx1-ubyte
+        train-labels-idx1-ubyte.gz
+```
+
+## Expected dataset structure for STL10
+
+The expected format is the exact same format used by torchvision, and the exact format obtained after either:
+- expanding the `stl10_binary.tar.gz` archive available at https://cs.stanford.edu/~acoates/stl10/
+- instantiating the `torchvision.datasets.STL10` class with `download=True`
+
+```
+stl10_binary/
+    class_names.txt
+    fold_indices.txt
+    test_X.bin
+    test_y.bin
+    train_X.bin
+    train_y.bin
+    unlabeled_X.bin
+```
+
 ## Dataset Catalog
 It contains a mapping from strings (which are names that identify a dataset,
 e.g. "imagenet1k_folder") to a `dict` which contains:
 1. mapping of various data splits (train, test, val) to the data source (path on the disk whether a folder path or a filelist)
-2. source of the data (`disk_filelist` | `disk_folder`)
+2. source of the data (`disk_filelist` | `disk_folder` | `torchvision_dataset`)
     - `disk_folder`: this is simply the root folder path to the downloaded data.
     - `disk_filelist`: These are numpy files: (1) file containing images information (2) file containing corresponding labels for images. We provide [scripts](https://github.com/facebookresearch/vissl/blob/master/extra_scripts/README.md) that can be used to prepare these two files for a dataset of choice.
+    - `torchvision_dataset`: the root folder path to the torchvision dowloaded dataset. As of now, the supported datasets are: CIFAR-10, CIFAR-100, MNIST and STL-10.
 
 The purpose of having this catalog is to make it easy to choose different datasets,
 by just using the strings in the config.

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -16,6 +16,7 @@ from vissl.data.dataset_catalog import (
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset
+from vissl.data.torchvision_dataset import TorchvisionDataset
 from vissl.utils.misc import setup_multiprocessing_method
 
 
@@ -29,6 +30,7 @@ __all__ = [
 DATASET_SOURCE_MAP = {
     "disk_filelist": DiskImageDataset,
     "disk_folder": DiskImageDataset,
+    "torchvision_dataset": TorchvisionDataset,
     "synthetic": SyntheticImageDataset,
 }
 

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -200,6 +200,8 @@ class GenericSSLDataset(Dataset):
                 # We do not create it again since it can be an expensive operation.
                 labels = [x[1] for x in self.data_objs[idx].image_dataset.samples]
                 labels = np.array(labels).astype(np.int64)
+            elif label_source == "torchvision_dataset":
+                labels = np.array(self.data_objs[idx].get_labels()).astype(np.int64)
             else:
                 raise ValueError(f"unknown label source: {label_source}")
             self.label_objs.append(labels)

--- a/vissl/data/ssl_transforms/img_pil_to_rgb_mode.py
+++ b/vissl/data/ssl_transforms/img_pil_to_rgb_mode.py
@@ -1,0 +1,59 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any, Dict, List, Union
+
+from PIL import Image
+from classy_vision.dataset.transforms import register_transform
+from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+
+
+@register_transform("ImgPil2RGB")
+class ImgPil2RGB(ClassyTransform):
+    """
+    Convert a PIL image to RGB mode.
+
+    This transform is necessary to adapt datasets such as MNIST (which has 1 color channel)
+    as input to traditional architectures (like ResNet50) requiring 3 color channels.
+
+    We first create an image of the same size as the original (or fixed "size" if provided as input) and
+    paste the original image in it. If a different size is provided, the "box" indicates where the paste
+    of the original image will be in the target image.
+
+    Default behavior (no arguments provided) is to keep the original image size.
+
+    The output is a PIL image in RGB mode.
+    """
+
+    def __init__(self, size: Union[int, List[int]], box: List[int]):
+        super().__init__()
+        if isinstance(size, int):
+            size = [size, size]
+        if size:
+            assert len(size) == 2, f"ImgPil2RGB: Expected \"size\" parameter of length 2, got: {size}"
+        assert len(box) == 2, f"ImgPil2RGB: Expected \"box\" parameter of length 2, got: {box}"
+        self.size = size
+        self.box = box
+
+    def __call__(self, original_img: Image.Image) -> Image.Image:
+        if self.size:
+            img = Image.new(mode="RGB", size=self.size)
+            img.paste(original_img, box=self.box)
+        else:
+            img = Image.new(mode="RGB", size=original_img.size)
+            img.paste(original_img)
+        return img
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "ImgPil2RGB":
+        """
+        Instantiates ImgPil2LabTensor from configuration.
+
+        Args:
+            config (Dict): arguments for for the transform
+
+        Returns:
+            ImgPil2RGB instance.
+        """
+        size = config.get("size", [])
+        box = config.get("box", [0, 0])
+        return cls(size=size, box=box)

--- a/vissl/data/ssl_transforms/mnist_img_pil_to_rgb_mode.py
+++ b/vissl/data/ssl_transforms/mnist_img_pil_to_rgb_mode.py
@@ -7,8 +7,8 @@ from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
 
 
-@register_transform("ImgPil2RGB")
-class ImgPil2RGB(ClassyTransform):
+@register_transform("MNISTImgPil2RGB")
+class MNISTImgPil2RGB(ClassyTransform):
     """
     Convert a PIL image to RGB mode.
 
@@ -44,7 +44,7 @@ class ImgPil2RGB(ClassyTransform):
         return img
 
     @classmethod
-    def from_config(cls, config: Dict[str, Any]) -> "ImgPil2RGB":
+    def from_config(cls, config: Dict[str, Any]) -> "MNISTImgPil2RGB":
         """
         Instantiates ImgPil2LabTensor from configuration.
 

--- a/vissl/data/ssl_transforms/mnist_img_pil_to_rgb_mode.py
+++ b/vissl/data/ssl_transforms/mnist_img_pil_to_rgb_mode.py
@@ -2,9 +2,9 @@
 
 from typing import Any, Dict, List, Union
 
-from PIL import Image
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+from PIL import Image
 
 
 @register_transform("MNISTImgPil2RGB")
@@ -29,8 +29,12 @@ class MNISTImgPil2RGB(ClassyTransform):
         if isinstance(size, int):
             size = [size, size]
         if size:
-            assert len(size) == 2, f"ImgPil2RGB: Expected \"size\" parameter of length 2, got: {size}"
-        assert len(box) == 2, f"ImgPil2RGB: Expected \"box\" parameter of length 2, got: {box}"
+            assert (
+                len(size) == 2
+            ), f'ImgPil2RGB: Expected "size" parameter of length 2, got: {size}'
+        assert (
+            len(box) == 2
+        ), f'ImgPil2RGB: Expected "box" parameter of length 2, got: {box}'
         self.size = size
         self.box = box
 

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Optional, Callable, Any
+from typing import Tuple, List
 
 from PIL import Image
 from fvcore.common.file_io import PathManager
@@ -6,6 +6,16 @@ from torch.utils.data import Dataset
 from torchvision.datasets import CIFAR10, CIFAR100, STL10, MNIST
 
 from vissl.utils.hydra_config import AttrDict
+
+
+class TorchvisionDatasetName:
+    """
+    Names of the Torchvision datasets currently supported in VISSL.
+    """
+    CIFAR10 = "CIFAR10"
+    CIFAR100 = "CIFAR100"
+    STL10 = "STL10"
+    MNIST = "MNIST"
 
 
 class TorchvisionDataset(Dataset):
@@ -19,7 +29,7 @@ class TorchvisionDataset(Dataset):
         data_source (string): data source ("torchvision_dataset") [not used]
         path (string): path to the dataset
         split (string): specify split for the dataset (either "train" or "val").
-        dataset_name (string): name of dataset.
+        dataset_name (string): name of dataset (should be one of TorchvisionDatasetName).
     """
 
     def __init__(self,
@@ -37,14 +47,14 @@ class TorchvisionDataset(Dataset):
 
     def _load_dataset(self):
         is_train_split = self.split == "train"
-        if self.dataset_name == "CIFAR10":
+        if self.dataset_name == TorchvisionDatasetName.CIFAR10:
             return CIFAR10(self.path, train=is_train_split)
-        elif self.dataset_name == "CIFAR100":
+        elif self.dataset_name == TorchvisionDatasetName.CIFAR100:
             return CIFAR100(self.path, train=is_train_split)
-        elif self.dataset_name == "STL10":
+        elif self.dataset_name == TorchvisionDatasetName.STL10:
             stl_split = "train" if is_train_split else "test"
             return STL10(self.path, split=stl_split)
-        elif self.dataset_name == "MNIST":
+        elif self.dataset_name == TorchvisionDatasetName.MNIST:
             return MNIST(root=self.path, train=is_train_split)
         else:
             raise ValueError(f"Unsupported dataset {self.dataset_name: str}")

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -4,7 +4,6 @@ from fvcore.common.file_io import PathManager
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision.datasets import CIFAR10, CIFAR100, MNIST, STL10
-
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -1,9 +1,9 @@
-from typing import Tuple, List
+from typing import List, Tuple
 
-from PIL import Image
 from fvcore.common.file_io import PathManager
+from PIL import Image
 from torch.utils.data import Dataset
-from torchvision.datasets import CIFAR10, CIFAR100, STL10, MNIST
+from torchvision.datasets import CIFAR10, CIFAR100, MNIST, STL10
 
 from vissl.utils.hydra_config import AttrDict
 
@@ -12,6 +12,7 @@ class TorchvisionDatasetName:
     """
     Names of the Torchvision datasets currently supported in VISSL.
     """
+
     CIFAR10 = "CIFAR10"
     CIFAR100 = "CIFAR100"
     STL10 = "STL10"
@@ -32,12 +33,9 @@ class TorchvisionDataset(Dataset):
         dataset_name (string): name of dataset (should be one of TorchvisionDatasetName).
     """
 
-    def __init__(self,
-                 cfg: AttrDict,
-                 data_source: str,
-                 path: str,
-                 split: str,
-                 dataset_name: str):
+    def __init__(
+        self, cfg: AttrDict, data_source: str, path: str, split: str, dataset_name: str
+    ):
         super().__init__()
         assert PathManager.isdir(path), f"Directory {path} does not exist"
         self.dataset_name = dataset_name

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -1,0 +1,110 @@
+from typing import Tuple, List, Optional, Callable, Any
+
+from PIL import Image
+from fvcore.common.file_io import PathManager
+from torch.utils.data import Dataset
+from torchvision.datasets import CIFAR10, CIFAR100, STL10, MNIST
+
+from vissl.utils.hydra_config import AttrDict
+
+
+class TorchvisionDataset(Dataset):
+    """
+    Adapter dataset to available datasets in Torchvision.
+    The selected dataset is based on the name provided as argument.
+    This name must match the names of the dataset in torchvision.
+
+    Args:
+        cfg (AttrDict): configuration defined by user
+        data_source (string): data source ("torchvision_dataset") [not used]
+        path (string): path to the dataset
+        split (string): specify split for the dataset (either "train" or "val").
+        dataset_name (string): name of dataset.
+    """
+
+    def __init__(self,
+                 cfg: AttrDict,
+                 data_source: str,
+                 path: str,
+                 split: str,
+                 dataset_name: str):
+        super().__init__()
+        assert PathManager.isdir(path), f"Directory {path} does not exist"
+        self.dataset_name = dataset_name
+        self.path = path
+        self.split = split.lower()
+        self.dataset = self._load_dataset()
+
+    def _load_dataset(self):
+        is_train_split = self.split == "train"
+        if self.dataset_name == "CIFAR10":
+            return CIFAR10(self.path, train=is_train_split)
+        elif self.dataset_name == "CIFAR100":
+            return CIFAR100(self.path, train=is_train_split)
+        elif self.dataset_name == "STL10":
+            stl_split = "train" if is_train_split else "test"
+            return STL10(self.path, split=stl_split)
+        elif self.dataset_name == "MNIST":
+            return MNISTAdapter(root=self.path, train=is_train_split)
+        else:
+            raise ValueError(f"Unsupported dataset {self.dataset_name: str}")
+
+    def num_samples(self) -> int:
+        """
+        Size of the dataset
+        """
+        return len(self.dataset)
+
+    def __len__(self) -> int:
+        """
+        Size of the dataset
+        """
+        return self.num_samples()
+
+    def __getitem__(self, idx: int) -> Tuple[Image.Image, bool]:
+        """
+        Return the image at index 'idx' and whether the load was successful
+        Note: we do delayed loading of data to reduce the memory size
+              due to pickling of dataset across dataloader workers.
+        """
+        image = self.dataset[idx][0]
+        is_success = True
+        return image, is_success
+
+    def get_labels(self) -> List[int]:
+        """
+        Return the labels for each sample
+        """
+        return [self.dataset[i][1] for i in range(self.num_samples())]
+
+
+class MNISTAdapter(MNIST):
+    """
+    Wrapper around MNIST to convert images to RGB and change the size of the images
+    to 32x32, to match the receptive field of a standard ResNet50.
+    """
+
+    def __init__(
+            self,
+            root: str,
+            train: bool = True,
+            transform: Optional[Callable] = None,
+            target_transform: Optional[Callable] = None,
+            download: bool = False):
+        super().__init__(
+            root=root,
+            train=train,
+            transform=transform,
+            target_transform=target_transform,
+            download=download)
+
+    def __getitem__(self, index: int) -> Tuple[Any, Any]:
+        original_img, target = self.data[index], int(self.targets[index])
+        original_img = Image.fromarray(original_img.numpy(), mode='L')
+        img = Image.new(mode="RGB", size=(32, 32))
+        img.paste(original_img, box=(2, 2, 30, 30))
+        if self.transform is not None:
+            img = self.transform(img)
+        if self.target_transform is not None:
+            target = self.target_transform(target)
+        return img, target

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -45,7 +45,7 @@ class TorchvisionDataset(Dataset):
             stl_split = "train" if is_train_split else "test"
             return STL10(self.path, split=stl_split)
         elif self.dataset_name == "MNIST":
-            return MNISTAdapter(root=self.path, train=is_train_split)
+            return MNIST(root=self.path, train=is_train_split)
         else:
             raise ValueError(f"Unsupported dataset {self.dataset_name: str}")
 
@@ -76,35 +76,3 @@ class TorchvisionDataset(Dataset):
         Return the labels for each sample
         """
         return [self.dataset[i][1] for i in range(self.num_samples())]
-
-
-class MNISTAdapter(MNIST):
-    """
-    Wrapper around MNIST to convert images to RGB and change the size of the images
-    to 32x32, to match the receptive field of a standard ResNet50.
-    """
-
-    def __init__(
-            self,
-            root: str,
-            train: bool = True,
-            transform: Optional[Callable] = None,
-            target_transform: Optional[Callable] = None,
-            download: bool = False):
-        super().__init__(
-            root=root,
-            train=train,
-            transform=transform,
-            target_transform=target_transform,
-            download=download)
-
-    def __getitem__(self, index: int) -> Tuple[Any, Any]:
-        original_img, target = self.data[index], int(self.targets[index])
-        original_img = Image.fromarray(original_img.numpy(), mode='L')
-        img = Image.new(mode="RGB", size=(32, 32))
-        img.paste(original_img, box=(2, 2, 30, 30))
-        if self.transform is not None:
-            img = self.transform(img)
-        if self.target_transform is not None:
-            target = self.target_transform(target)
-        return img, target

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -74,8 +74,6 @@ class TorchvisionDataset(Dataset):
     def __getitem__(self, idx: int) -> Tuple[Image.Image, bool]:
         """
         Return the image at index 'idx' and whether the load was successful
-        Note: we do delayed loading of data to reduce the memory size
-              due to pickling of dataset across dataloader workers.
         """
         image = self.dataset[idx][0]
         is_success = True


### PR DESCRIPTION
This PR is a revision of the first PR (https://github.com/facebookresearch/vissl/pull/165) which was a draft to discuss the approach to integrate these datasets. Compared to the previous PR:

1. More pytorch datasets are included (CIFAR10, CIFAR100, STL10, MNIST)
2. The different datasets are proposed in benchmark/linear_image_classification/datasets

To combine the datasets with the standard linear evaluation benchmark, we can use the following hydra syntax

```
python tools/run_distributed_engines.py config=benchmark/linear_image_classification/imagenet1k/eval_resnet_8gpu_transfer_in1k_linear config.MODEL.WEIGHTS_INIT.PARAMS_FILE=PATH +config/benchmark/linear_image_classification/datasets=cifar10
```

Note that for MNIST, a wrapper dataset was needed to convert the images from 1 channel to 3 channels, and increase their size to 32x32 to at least match the downsampling by 32 of standard Resnet50.