### PR TITLE
Update to isort 5.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
       - run:
           name: isort
           command: |
-            isort -y -sp .
+            isort --sp . .
       - run:
           name: black
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,14 @@ repos:
     -   id: flake8
         args: ['--max-line-length=88', '--ignore=E501,E203,E266,W503,E741']
 
-# -   repo: https://github.com/asottile/seed-isort-config
-#     rev: v2.1.0
-#     hooks:
-#     -   id: seed-isort-config
-#         language_version: python3.6
-
--   repo: https://github.com/timothycrosley/isort
-    rev: 4.3.20
-    hooks:
-    -   id: isort
+- repo: https://github.com/pycqa/isort
+  rev: 5.6.3
+  hooks:
+    - id: isort
+      name: isort (python)
+    - id: isort
+      name: isort (cython)
+      types: [cython]
+    - id: isort
+      name: isort (pyi)
+      types: [pyi]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,11 @@ repos:
     -   id: flake8
         args: ['--max-line-length=88', '--ignore=E501,E203,E266,W503,E741']
 
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
-    hooks:
-    -   id: seed-isort-config
-        language_version: python3.6
+# -   repo: https://github.com/asottile/seed-isort-config
+#     rev: v2.1.0
+#     hooks:
+#     -   id: seed-isort-config
+#         language_version: python3.6
 
 -   repo: https://github.com/timothycrosley/isort
     rev: 4.3.20

--- a/dev/linter.sh
+++ b/dev/linter.sh
@@ -17,7 +17,7 @@ DIR=$(dirname "${DIR}")
 echo "$DIR"
 
 echo "Running isort..."
-isort -c -sp "${DIR}"
+isort -c --sp "${DIR}" "${DIR}"
 
 echo "Running black..."
 black "${DIR}"

--- a/dev/packaging/apex_conda/inside/build.py
+++ b/dev/packaging/apex_conda/inside/build.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 
+
 os.environ["SOURCE_ROOT_DIR"] = "/inside/apex"
 os.environ["CONDA_CPUONLY_FEATURE"] = ""
 

--- a/dev/packaging/vissl_pip/publish.py
+++ b/dev/packaging/vissl_pip/publish.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 from pathlib import Path
 
+
 dest = "s3://dl.fbaipublicfiles.com/vissl/packaging/visslwheels/"
 
 # we build on python3.6 but it works for 3.7, 3.8 and 3.9 too

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ except ImportError:
 
 
 # -- Project information -----------------------------------------------------
-import vissl  # isort: skip
+import vissl  # isort:skip
 
 project = "VISSL"
 copyright = "2021, VISSL contributors"

--- a/extra_scripts/convert_vissl_to_torchvision.py
+++ b/extra_scripts/convert_vissl_to_torchvision.py
@@ -10,6 +10,7 @@ import sys
 
 import torch
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.checkpoint import replace_module_prefix
 from vissl.utils.io import is_url
 

--- a/extra_scripts/create_low_shot_samples.py
+++ b/extra_scripts/create_low_shot_samples.py
@@ -9,6 +9,7 @@ import random
 
 import numpy as np
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.io import load_file, save_file
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,5 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = True
 lines_after_imports = 2
+known_third_party = PIL,bs4,classy_vision,cv2,detectron2,fairscale,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,run_distributed_engines,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
 skip_glob = build/*,third-party/*,.github/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,4 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = True
 lines_after_imports = 2
-known_third_party = PIL,bs4,classy_vision,cv2,detectron2,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,run_distributed_engines,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
 skip_glob = build/*,third-party/*,.github/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ line_length = 88
 multi_line_output = 3
 use_parentheses = True
 lines_after_imports = 2
-known_third_party = PIL,bs4,classy_vision,cv2,detectron2,fairscale,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,run_distributed_engines,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
+known_third_party = PIL,bs4,classy_vision,cv2,detectron2,faiss,fvcore,hydra,mock,nbconvert,nbformat,numpy,omegaconf,parameterized,pkg_resources,pycocotools,recommonmark,run_distributed_engines,scipy,setuptools,sklearn,sphinx_rtd_theme,tabulate,torch,torchvision,tqdm,utils
 skip_glob = build/*,third-party/*,.github/*

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "dev": [
             "black==19.3b0",
             "sphinx",
-            "isort==4.3.21",
+            "isort==5.7.0",
             "flake8==3.8.1",
             "flake8-bugbear",
             "flake8-comprehensions",

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -11,6 +11,7 @@ from utils import (
     PRETRAIN_CONFIGS,
     SSLHydraConfig,
 )
+
 from vissl.utils.hydra_config import convert_to_attrdict
 
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -10,6 +10,7 @@ import torch.multiprocessing as mp
 from classy_vision.generic.distributed_util import set_cpu_device
 from parameterized import parameterized
 from utils import ROOT_LOSS_CONFIGS, SSLHydraConfig
+
 from vissl.losses.multicrop_simclr_info_nce_loss import MultiCropSimclrInfoNCECriterion
 from vissl.losses.simclr_info_nce_loss import SimclrInfoNCECriterion
 from vissl.losses.swav_loss import SwAVCriterion

--- a/tests/test_meter_build.py
+++ b/tests/test_meter_build.py
@@ -5,6 +5,7 @@ import unittest
 
 from parameterized import parameterized
 from utils import ROOT_LOSS_CONFIGS, SSLHydraConfig
+
 from vissl.trainer.train_task import SelfSupervisionTask
 from vissl.utils.hydra_config import convert_to_attrdict
 

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -1,7 +1,8 @@
 import unittest
 
 import torch
-from vissl.models.heads import LinearEvalMLP, MLP
+
+from vissl.models.heads import MLP, LinearEvalMLP
 from vissl.utils.hydra_config import AttrDict
 
 
@@ -11,13 +12,15 @@ class TestMLP(unittest.TestCase):
     and linear evaluation MLP layers
     """
 
-    MODEL_CONFIG = AttrDict({
-        "HEAD": {
-            "BATCHNORM_EPS": 1e-6,
-            "BATCHNORM_MOMENTUM": 0.99,
-            "PARAMS_MULTIPLIER": 1.0,
+    MODEL_CONFIG = AttrDict(
+        {
+            "HEAD": {
+                "BATCHNORM_EPS": 1e-6,
+                "BATCHNORM_MOMENTUM": 0.99,
+                "PARAMS_MULTIPLIER": 1.0,
+            }
         }
-    })
+    )
 
     def test_mlp(self):
         mlp = MLP(self.MODEL_CONFIG, dims=[2048, 100])
@@ -47,9 +50,7 @@ class TestMLP(unittest.TestCase):
 
     def test_eval_mlp_shape(self):
         eval_mlp = LinearEvalMLP(
-            self.MODEL_CONFIG,
-            in_channels=2048,
-            dims=[2048 * 2 * 2, 1000],
+            self.MODEL_CONFIG, in_channels=2048, dims=[2048 * 2 * 2, 1000]
         )
 
         resnet_feature_map = torch.randn(size=(4, 2048, 2, 2))

--- a/tests/test_model_load.py
+++ b/tests/test_model_load.py
@@ -10,6 +10,7 @@ from utils import (
     PRETRAIN_CONFIGS,
     SSLHydraConfig,
 )
+
 from vissl.models import build_model
 from vissl.utils.hydra_config import convert_to_attrdict
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ import unittest
 import pkg_resources
 from parameterized import parameterized
 from utils import UNIT_TEST_CONFIGS, SSLHydraConfig
+
 from vissl.engines.train import train_main
 from vissl.hooks import default_hook_generator
 from vissl.utils.checkpoint import get_checkpoint_folder

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 from PIL import Image
 from torchvision.transforms import Compose, ToTensor
+
 from vissl.data.ssl_transforms.img_pil_to_tensor import ImgToTensor
 from vissl.data.ssl_transforms.mnist_img_pil_to_rgb_mode import MNISTImgPil2RGB
 

--- a/tools/cluster_features_and_label.py
+++ b/tools/cluster_features_and_label.py
@@ -13,6 +13,7 @@ from typing import Any, List
 import faiss
 import numpy as np
 from hydra.experimental import compose, initialize_config_module
+
 from vissl.data import build_dataset
 from vissl.hooks import default_hook_generator
 from vissl.utils.checkpoint import get_checkpoint_folder

--- a/tools/instance_retrieval_test.py
+++ b/tools/instance_retrieval_test.py
@@ -13,6 +13,7 @@ import torchvision
 from classy_vision.generic.util import copy_model_to_gpu
 from fvcore.common.file_io import PathManager
 from hydra.experimental import compose, initialize_config_module
+
 from vissl.models import build_model
 from vissl.utils.checkpoint import init_model_from_weights
 from vissl.utils.env import set_env_vars

--- a/tools/nearest_neighbor_test.py
+++ b/tools/nearest_neighbor_test.py
@@ -8,6 +8,7 @@ from typing import Any, List
 import torch
 from hydra.experimental import compose, initialize_config_module
 from torch import nn
+
 from vissl.hooks import default_hook_generator
 from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.utils.checkpoint import get_checkpoint_folder

--- a/tools/perf_measurement/benchmark_data.py
+++ b/tools/perf_measurement/benchmark_data.py
@@ -8,6 +8,7 @@ import torch
 import tqdm
 from fvcore.common.timer import Timer
 from hydra.experimental import compose, initialize_config_module
+
 from vissl.data import build_dataset, get_loader
 from vissl.utils.hydra_config import AttrDict, convert_to_attrdict, is_hydra_available
 from vissl.utils.logger import setup_logging

--- a/tools/perf_measurement/benchmark_transforms.py
+++ b/tools/perf_measurement/benchmark_transforms.py
@@ -6,6 +6,7 @@ from typing import Callable, List
 import torch
 import torchvision.transforms as transforms
 from PIL import Image
+
 from vissl.data.ssl_transforms.img_cv_color_distortion import (
     ColorDistortionSettings,
     ImgOpenCVColorDistortion,

--- a/tools/run_distributed_engines.py
+++ b/tools/run_distributed_engines.py
@@ -7,14 +7,15 @@ Supports SLURM as an option. Set config.SLURM.USE_SLURM=true to use slurm.
 """
 
 import sys
-from typing import List, Any
+from typing import Any, List
 
-from hydra.experimental import initialize_config_module, compose
+from hydra.experimental import compose, initialize_config_module
+
 from vissl.utils.distributed_launcher import (
     launch_distributed,
     launch_distributed_on_slurm,
 )
-from vissl.utils.hydra_config import is_hydra_available, convert_to_attrdict
+from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available
 from vissl.utils.slurm import is_submitit_available
 
 

--- a/tools/train_svm.py
+++ b/tools/train_svm.py
@@ -8,6 +8,7 @@ from typing import Any, List
 
 import numpy as np
 from hydra.experimental import compose, initialize_config_module
+
 from vissl.hooks import default_hook_generator
 from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.utils.checkpoint import get_checkpoint_folder

--- a/tools/train_svm_low_shot.py
+++ b/tools/train_svm_low_shot.py
@@ -6,11 +6,12 @@ import sys
 from argparse import Namespace
 from typing import Any, List
 
+from hydra.experimental import compose, initialize_config_module
+
 from extra_scripts.create_low_shot_samples import (
     generate_low_shot_samples,
     generate_places_low_shot_samples,
 )
-from hydra.experimental import compose, initialize_config_module
 from vissl.data import dataset_catalog
 from vissl.hooks import default_hook_generator
 from vissl.models.model_helpers import get_trunk_output_feature_names

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -5,6 +5,7 @@ import logging
 import torch
 from classy_vision.dataset import DataloaderAsyncGPUWrapper
 from torch.utils.data import DataLoader
+
 from vissl.data.collators import get_collator
 from vissl.data.data_helper import StatefulDistributedSampler
 from vissl.data.dataloader_sync_gpu_wrapper import DataloaderSyncGPUWrapper

--- a/vissl/data/collators/mixup_collator.py
+++ b/vissl/data/collators/mixup_collator.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/moco_collator.py
+++ b/vissl/data/collators/moco_collator.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/multicrop_collator.py
+++ b/vissl/data/collators/multicrop_collator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/patch_and_image_collator.py
+++ b/vissl/data/collators/patch_and_image_collator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/siamese_collator.py
+++ b/vissl/data/collators/siamese_collator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/simclr_collator.py
+++ b/vissl/data/collators/simclr_collator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/collators/targets_one_hot_default_collator.py
+++ b/vissl/data/collators/targets_one_hot_default_collator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
+
 from vissl.data.collators import register_collator
 
 

--- a/vissl/data/dataset_catalog.py
+++ b/vissl/data/dataset_catalog.py
@@ -11,6 +11,7 @@ from typing import List
 
 import numpy as np
 from fvcore.common.file_io import PathManager
+
 from vissl.data.datasets import get_coco_imgs_labels_info, get_voc_images_labels_info
 from vissl.utils.misc import get_json_data_catalog_file
 from vissl.utils.slurm import get_slurm_dir

--- a/vissl/data/datasets/pascal_voc.py
+++ b/vissl/data/datasets/pascal_voc.py
@@ -12,6 +12,7 @@ from glob import glob
 
 import numpy as np
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.io import makedir, save_file
 
 

--- a/vissl/data/disk_dataset.py
+++ b/vissl/data/disk_dataset.py
@@ -5,6 +5,7 @@ import logging
 from fvcore.common.file_io import PathManager
 from PIL import Image
 from torchvision.datasets import ImageFolder
+
 from vissl.data.data_helper import QueueDataset, get_mean_image
 from vissl.utils.io import load_file
 

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -6,6 +6,7 @@ import numpy as np
 from classy_vision.generic.distributed_util import get_world_size
 from fvcore.common.file_io import PathManager
 from torch.utils.data import Dataset
+
 from vissl.data import dataset_catalog
 from vissl.data.ssl_transforms import get_transform
 from vissl.utils.env import get_machine_local_and_dist_rank

--- a/vissl/data/ssl_transforms/img_pil_random_photometric.py
+++ b/vissl/data/ssl_transforms/img_pil_random_photometric.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import torchvision.transforms as pth_transforms
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+
 from vissl.data.ssl_transforms.pil_photometric_transforms_lib import (
     AutoContrastTransform,
     RandomPosterizeTransform,

--- a/vissl/data/ssl_transforms/img_pil_random_solarize.py
+++ b/vissl/data/ssl_transforms/img_pil_random_solarize.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import torchvision.transforms as pth_transforms
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+
 from vissl.data.ssl_transforms.pil_photometric_transforms_lib import (
     RandomSolarizeTransform,
 )

--- a/vissl/data/ssl_transforms/img_pil_to_patches_and_image.py
+++ b/vissl/data/ssl_transforms/img_pil_to_patches_and_image.py
@@ -7,6 +7,7 @@ import PIL
 import torchvision.transforms as pth_transforms
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+
 from vissl.data.ssl_transforms.img_patches_tensor import ImgPatchesFromTensor
 
 

--- a/vissl/data/ssl_transforms/shuffle_img_patches.py
+++ b/vissl/data/ssl_transforms/shuffle_img_patches.py
@@ -8,6 +8,7 @@ import torch
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.io import load_file
 
 

--- a/vissl/data/synthetic_dataset.py
+++ b/vissl/data/synthetic_dataset.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 from torch.utils.data import Dataset
+
 from vissl.data.data_helper import get_mean_image
 
 

--- a/vissl/data/torchvision_dataset.py
+++ b/vissl/data/torchvision_dataset.py
@@ -4,6 +4,7 @@ from fvcore.common.file_io import PathManager
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision.datasets import CIFAR10, CIFAR100, MNIST, STL10
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/engines/train.py
+++ b/vissl/engines/train.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, List
 
 import torch
 from classy_vision.hooks.classy_hook import ClassyHook
+
 from vissl.hooks import default_hook_generator
 from vissl.trainer import SelfSupervisionTrainer
 from vissl.utils.collect_env import collect_env_info

--- a/vissl/hooks/__init__.py
+++ b/vissl/hooks/__init__.py
@@ -4,10 +4,11 @@ from enum import Enum, auto
 from typing import List
 
 from classy_vision.hooks.classy_hook import ClassyHook
+
 from vissl.hooks.deepclusterv2_hooks import ClusterMemoryHook, InitMemoryHook  # noqa
 from vissl.hooks.log_hooks import (  # noqa
-    LogGpuStatsHook,
     LogGpuMemoryHook,
+    LogGpuStatsHook,
     LogLossLrEtaHook,
     LogLossMetricsCheckpointHook,
     LogPerfTimeMetricsHook,

--- a/vissl/hooks/log_hooks.py
+++ b/vissl/hooks/log_hooks.py
@@ -15,6 +15,7 @@ from classy_vision.generic.distributed_util import get_rank, is_primary
 from classy_vision.generic.util import save_checkpoint
 from classy_vision.hooks.classy_hook import ClassyHook
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.checkpoint import is_checkpoint_phase
 from vissl.utils.env import get_machine_local_and_dist_rank
 from vissl.utils.io import create_file_symlink, save_file
@@ -34,10 +35,7 @@ class LogGpuMemoryHook(ClassyHook):
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop
 
-    def __init__(
-        self,
-        log_iteration_num: int = 1,
-    ) -> None:
+    def __init__(self, log_iteration_num: int = 1) -> None:
         super().__init__()
         self.log_iteration_num = log_iteration_num
 

--- a/vissl/hooks/moco_hooks.py
+++ b/vissl/hooks/moco_hooks.py
@@ -6,6 +6,7 @@ import torch
 from classy_vision import tasks
 from classy_vision.generic.distributed_util import is_distributed_training_run
 from classy_vision.hooks.classy_hook import ClassyHook
+
 from vissl.models import build_model
 from vissl.utils.env import get_machine_local_and_dist_rank
 from vissl.utils.misc import concat_all_gather

--- a/vissl/hooks/swav_momentum_hooks.py
+++ b/vissl/hooks/swav_momentum_hooks.py
@@ -7,6 +7,7 @@ from classy_vision import tasks
 from classy_vision.generic.distributed_util import init_distributed_data_parallel_model
 from classy_vision.hooks.classy_hook import ClassyHook
 from torch import nn
+
 from vissl.models import build_model
 from vissl.utils.env import get_machine_local_and_dist_rank
 

--- a/vissl/losses/bce_logits_multiple_output_single_target.py
+++ b/vissl/losses/bce_logits_multiple_output_single_target.py
@@ -6,6 +6,7 @@ import torch
 from classy_vision.generic.util import is_on_gpu
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/losses/cross_entropy_multiple_output_single_target.py
+++ b/vissl/losses/cross_entropy_multiple_output_single_target.py
@@ -6,6 +6,7 @@ import torch
 from classy_vision.generic.util import is_on_gpu
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/losses/deepclusterv2_loss.py
+++ b/vissl/losses/deepclusterv2_loss.py
@@ -14,6 +14,7 @@ from classy_vision.generic.distributed_util import (
 )
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 from vissl.utils.misc import get_indices_sparse
 

--- a/vissl/losses/moco_loss.py
+++ b/vissl/losses/moco_loss.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 import torch
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.misc import concat_all_gather
 
 

--- a/vissl/losses/multicrop_simclr_info_nce_loss.py
+++ b/vissl/losses/multicrop_simclr_info_nce_loss.py
@@ -6,6 +6,7 @@ import pprint
 import numpy as np
 import torch
 from classy_vision.losses import register_loss
+
 from vissl.losses.simclr_info_nce_loss import SimclrInfoNCECriterion, SimclrInfoNCELoss
 from vissl.utils.hydra_config import AttrDict
 

--- a/vissl/losses/nce_loss.py
+++ b/vissl/losses/nce_loss.py
@@ -15,6 +15,7 @@ from classy_vision.generic.distributed_util import (
 from classy_vision.generic.util import is_pos_int
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/losses/simclr_info_nce_loss.py
+++ b/vissl/losses/simclr_info_nce_loss.py
@@ -8,6 +8,7 @@ import torch
 from classy_vision.generic.distributed_util import get_cuda_device_index, get_rank
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.distributed_gradients import gather_from_all
 from vissl.utils.hydra_config import AttrDict
 

--- a/vissl/losses/swav_loss.py
+++ b/vissl/losses/swav_loss.py
@@ -18,6 +18,7 @@ from classy_vision.generic.distributed_util import (
 from classy_vision.losses import ClassyLoss, register_loss
 from fvcore.common.file_io import PathManager
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/losses/swav_momentum_loss.py
+++ b/vissl/losses/swav_momentum_loss.py
@@ -14,6 +14,7 @@ from classy_vision.generic.distributed_util import (
 )
 from classy_vision.losses import ClassyLoss, register_loss
 from torch import nn
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/meters/accuracy_list_meter.py
+++ b/vissl/meters/accuracy_list_meter.py
@@ -5,6 +5,7 @@ from typing import List, Union
 import torch
 from classy_vision.generic.util import is_pos_int
 from classy_vision.meters import AccuracyMeter, ClassyMeter, register_meter
+
 from vissl.utils.hydra_config import AttrDict
 
 

--- a/vissl/meters/mean_ap_list_meter.py
+++ b/vissl/meters/mean_ap_list_meter.py
@@ -5,6 +5,7 @@ from typing import List, Union
 import torch
 from classy_vision.generic.util import is_pos_int
 from classy_vision.meters import ClassyMeter, register_meter
+
 from vissl.meters.mean_ap_meter import MeanAPMeter
 from vissl.utils.hydra_config import AttrDict
 

--- a/vissl/meters/mean_ap_list_meter.py
+++ b/vissl/meters/mean_ap_list_meter.py
@@ -60,10 +60,7 @@ class MeanAPListMeter(ClassyMeter):
         for ind, meter in enumerate(self._meters):
             meter_val = meter.value
             sample_count = meter._scores.shape[0]
-            val_dict[ind] = {
-                "val": meter_val,
-                "sample_count": sample_count,
-            }
+            val_dict[ind] = {"val": meter_val, "sample_count": sample_count}
         output_dict = {}
         output_dict["mAP"] = {}
         output_dict["AP"] = {}
@@ -98,9 +95,7 @@ class MeanAPListMeter(ClassyMeter):
         meter_states = {}
         for ind, meter in enumerate(self._meters):
             state = meter.get_classy_state()
-            meter_states[ind] = {
-                "state": state,
-            }
+            meter_states[ind] = {"state": state}
         return meter_states
 
     def set_classy_state(self, state):

--- a/vissl/meters/mean_ap_meter.py
+++ b/vissl/meters/mean_ap_meter.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 from classy_vision.generic.distributed_util import all_reduce_sum, gather_from_all
 from classy_vision.meters import ClassyMeter, register_meter
+
 from vissl.utils.env import get_machine_local_and_dist_rank
 from vissl.utils.hydra_config import AttrDict
 from vissl.utils.svm_utils.evaluate import get_precision_recall

--- a/vissl/models/base_ssl_model.py
+++ b/vissl/models/base_ssl_model.py
@@ -6,6 +6,7 @@ import logging
 import torch
 import torch.nn as nn
 from classy_vision.models import ClassyModel, register_model
+
 from vissl.models.heads import get_model_head
 from vissl.models.model_helpers import (
     get_trunk_output_feature_names,

--- a/vissl/models/heads/linear_eval_mlp.py
+++ b/vissl/models/heads/linear_eval_mlp.py
@@ -3,6 +3,7 @@ from typing import List
 
 import torch
 import torch.nn as nn
+
 from vissl.models.heads import register_model_head
 from vissl.models.heads.mlp import MLP
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/heads/mlp.py
+++ b/vissl/models/heads/mlp.py
@@ -3,6 +3,7 @@ from typing import List
 
 import torch
 import torch.nn as nn
+
 from vissl.models.heads import register_model_head
 from vissl.utils.hydra_config import AttrDict
 
@@ -92,8 +93,8 @@ class MLP(nn.Module):
             ), "MLP input should be either a tensor (2D, 4D) or list containing 1 tensor."
             batch = batch[0]
         if batch.ndim > 2:
-            assert (
-                    all(d == 1 for d in batch.shape[2:])
+            assert all(
+                d == 1 for d in batch.shape[2:]
             ), f"MLP expected 2D input tensor or 4D tensor of shape NxCx1x1. got: {batch.shape}"
             batch = batch.reshape((batch.size(0), batch.size(1)))
         out = self.clf(batch)

--- a/vissl/models/heads/siamese_concat_view.py
+++ b/vissl/models/heads/siamese_concat_view.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn as nn
+
 from vissl.models.heads import register_model_head
 from vissl.utils.hydra_config import AttrDict
 

--- a/vissl/models/heads/swav_prototypes_head.py
+++ b/vissl/models/heads/swav_prototypes_head.py
@@ -3,6 +3,7 @@ from typing import List
 
 import torch
 import torch.nn as nn
+
 from vissl.models.heads import register_model_head
 from vissl.utils.hydra_config import AttrDict
 

--- a/vissl/models/model_helpers.py
+++ b/vissl/models/model_helpers.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 import torch
 import torch.nn as nn
 from torch.utils.checkpoint import checkpoint
+
 from vissl.utils.activation_checkpointing import checkpoint_trunk
 from vissl.utils.misc import is_apex_available
 

--- a/vissl/models/trunks/alexnet_bvlc.py
+++ b/vissl/models/trunks/alexnet_bvlc.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch.nn as nn
+
 from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/alexnet_colorization.py
+++ b/vissl/models/trunks/alexnet_colorization.py
@@ -2,10 +2,7 @@
 
 import torch
 import torch.nn as nn
-from vissl.models.model_helpers import (
-    Flatten,
-    get_trunk_forward_outputs_module_list,
-)
+from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict
 
@@ -87,9 +84,6 @@ class AlexNetColorization(nn.Module):
         # along the channel dimension into [L, AB] and keep only L channel.
         feat = torch.split(feat, [1, 2], dim=1)[0]
         out_feats = get_trunk_forward_outputs_module_list(
-            feat,
-            out_feat_keys,
-            self._feature_blocks,
-            self.all_feat_names,
+            feat, out_feat_keys, self._feature_blocks, self.all_feat_names
         )
         return out_feats

--- a/vissl/models/trunks/alexnet_colorization.py
+++ b/vissl/models/trunks/alexnet_colorization.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn as nn
+
 from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/alexnet_deepcluster.py
+++ b/vissl/models/trunks/alexnet_deepcluster.py
@@ -101,9 +101,6 @@ class AlexNetDeepCluster(nn.Module):
         # we first apply sobel filter
         feat = self.sobel(feat)
         out_feats = get_trunk_forward_outputs_module_list(
-            feat,
-            out_feat_keys,
-            self._feature_blocks,
-            self.all_feat_names,
+            feat, out_feat_keys, self._feature_blocks, self.all_feat_names
         )
         return out_feats

--- a/vissl/models/trunks/alexnet_deepcluster.py
+++ b/vissl/models/trunks/alexnet_deepcluster.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn as nn
+
 from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/alexnet_jigsaw.py
+++ b/vissl/models/trunks/alexnet_jigsaw.py
@@ -80,9 +80,6 @@ class AlexNetJigsaw(nn.Module):
     def forward(self, x, out_feat_keys=None):
         feat = x
         out_feats = get_trunk_forward_outputs_module_list(
-            feat,
-            out_feat_keys,
-            self._feature_blocks,
-            self.all_feat_names,
+            feat, out_feat_keys, self._feature_blocks, self.all_feat_names
         )
         return out_feats

--- a/vissl/models/trunks/alexnet_jigsaw.py
+++ b/vissl/models/trunks/alexnet_jigsaw.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch.nn as nn
+
 from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/alexnet_rotnet.py
+++ b/vissl/models/trunks/alexnet_rotnet.py
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/gidariss/FeatureLearningRotNet
 
 import torch.nn as nn
+
 from vissl.models.model_helpers import Flatten, get_trunk_forward_outputs_module_list
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/alexnet_rotnet.py
+++ b/vissl/models/trunks/alexnet_rotnet.py
@@ -63,9 +63,6 @@ class AlexNetRotNet(nn.Module):
     def forward(self, x, out_feat_keys=None):
         feat = x
         out_feats = get_trunk_forward_outputs_module_list(
-            feat,
-            out_feat_keys,
-            self._feature_blocks,
-            self.all_feat_names,
+            feat, out_feat_keys, self._feature_blocks, self.all_feat_names
         )
         return out_feats

--- a/vissl/models/trunks/efficientnet.py
+++ b/vissl/models/trunks/efficientnet.py
@@ -9,6 +9,7 @@ from classy_vision.models.efficientnet import (
     MODEL_PARAMS,
     EfficientNet as ClassyEfficientNet,
 )
+
 from vissl.models.model_helpers import Flatten, Wrap, parse_out_keys_arg
 from vissl.models.trunks import register_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/feature_extractor.py
+++ b/vissl/models/trunks/feature_extractor.py
@@ -3,6 +3,7 @@ import logging
 
 import torch
 import torch.nn as nn
+
 from vissl.models.model_helpers import Identity
 from vissl.models.trunks import get_model_trunk
 from vissl.utils.hydra_config import AttrDict

--- a/vissl/models/trunks/regnet.py
+++ b/vissl/models/trunks/regnet.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 from classy_vision.models import RegNet as ClassyRegNet, build_model
+
 from vissl.models.model_helpers import (
     Flatten,
     get_trunk_forward_outputs,

--- a/vissl/models/trunks/resnext.py
+++ b/vissl/models/trunks/resnext.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torchvision.models as models
 from torchvision.models.resnet import Bottleneck
+
 from vissl.models.model_helpers import (
     Flatten,
     _get_norm,

--- a/vissl/optimizers/optimizer_helper.py
+++ b/vissl/optimizers/optimizer_helper.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, List
 
 import torch.nn as nn
+
 from vissl.utils.misc import is_apex_available
 
 

--- a/vissl/trainer/train_steps/standard_train_step.py
+++ b/vissl/trainer/train_steps/standard_train_step.py
@@ -20,6 +20,7 @@ from vissl.utils.activation_checkpointing import (
 from vissl.utils.misc import is_apex_available
 from vissl.utils.perf_stats import PerfTimer
 
+
 if is_apex_available():
     import apex
 

--- a/vissl/trainer/train_steps/standard_train_step.py
+++ b/vissl/trainer/train_steps/standard_train_step.py
@@ -11,6 +11,7 @@ import torch
 from classy_vision.generic.distributed_util import all_reduce_mean
 from classy_vision.tasks import ClassyTask
 from classy_vision.tasks.classification_task import AmpType
+
 from vissl.hooks import SSLClassyHookFunctions
 from vissl.trainer.train_steps import register_train_step
 from vissl.utils.activation_checkpointing import (

--- a/vissl/trainer/train_task.py
+++ b/vissl/trainer/train_task.py
@@ -12,6 +12,7 @@ from classy_vision.tasks import ClassificationTask, register_task
 from classy_vision.tasks.classification_task import AmpType, BroadcastBuffersMode
 from fvcore.common.file_io import PathManager
 from torch.cuda.amp import GradScaler as TorchGradScaler
+
 from vissl.data import build_dataset, get_loader, print_sampler_config
 from vissl.models import build_model, convert_sync_bn
 from vissl.optimizers import get_optimizer_param_groups

--- a/vissl/trainer/train_task.py
+++ b/vissl/trainer/train_task.py
@@ -4,15 +4,12 @@ import gc
 import logging
 
 import torch
-from classy_vision.generic.util import (
-    copy_model_to_gpu,
-    load_and_broadcast_checkpoint,
-)
+from classy_vision.generic.util import copy_model_to_gpu, load_and_broadcast_checkpoint
 from classy_vision.losses import build_loss
 from classy_vision.meters import build_meter
 from classy_vision.optim import build_optimizer, build_optimizer_schedulers
 from classy_vision.tasks import ClassificationTask, register_task
-from classy_vision.tasks.classification_task import BroadcastBuffersMode, AmpType
+from classy_vision.tasks.classification_task import AmpType, BroadcastBuffersMode
 from fvcore.common.file_io import PathManager
 from torch.cuda.amp import GradScaler as TorchGradScaler
 from vissl.data import build_dataset, get_loader, print_sampler_config
@@ -22,6 +19,7 @@ from vissl.utils.activation_checkpointing import manual_gradient_reduction
 from vissl.utils.checkpoint import init_model_from_weights
 from vissl.utils.hydra_config import AttrDict
 from vissl.utils.misc import is_apex_available, is_fairscale_sharded_available
+
 
 if is_apex_available():
     import apex

--- a/vissl/trainer/trainer_main.py
+++ b/vissl/trainer/trainer_main.py
@@ -17,7 +17,7 @@ from classy_vision.generic.distributed_util import (
 )
 from classy_vision.generic.util import copy_model_to_gpu
 from classy_vision.hooks.classy_hook import ClassyHook
-from classy_vision.tasks import ClassyTask, TASK_REGISTRY
+from classy_vision.tasks import TASK_REGISTRY, ClassyTask
 from vissl.hooks import SSLClassyHookFunctions
 from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.trainer.train_steps import get_train_step

--- a/vissl/trainer/trainer_main.py
+++ b/vissl/trainer/trainer_main.py
@@ -18,6 +18,7 @@ from classy_vision.generic.distributed_util import (
 from classy_vision.generic.util import copy_model_to_gpu
 from classy_vision.hooks.classy_hook import ClassyHook
 from classy_vision.tasks import TASK_REGISTRY, ClassyTask
+
 from vissl.hooks import SSLClassyHookFunctions
 from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.trainer.train_steps import get_train_step

--- a/vissl/utils/activation_checkpointing.py
+++ b/vissl/utils/activation_checkpointing.py
@@ -131,12 +131,7 @@ def checkpoint_trunk(
 
         feature_blocks_bucketed = (
             feature_blocks_bucketed[:i_max]
-            + [
-                [
-                    f"activation_split_{split_times}",
-                    biggest_block[1][:n_split_layers],
-                ]
-            ]
+            + [[f"activation_split_{split_times}", biggest_block[1][:n_split_layers]]]
             + [[biggest_block[0], biggest_block[1][n_split_layers:]]]
             + feature_blocks_bucketed[(i_max + 1) :]
         )

--- a/vissl/utils/checkpoint.py
+++ b/vissl/utils/checkpoint.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 import torch
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.env import get_machine_local_and_dist_rank
 from vissl.utils.hydra_config import AttrDict
 from vissl.utils.io import makedir

--- a/vissl/utils/distributed_launcher.py
+++ b/vissl/utils/distributed_launcher.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, List
 
 import torch
 from fvcore.common.file_io import PathManager
+
 from vissl.data.dataset_catalog import get_data_files
 from vissl.engines.extract_features import extract_main
 from vissl.engines.train import train_main

--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any, List
 
 from omegaconf import DictConfig, OmegaConf
+
 from vissl.config import check_cfg_version
 
 

--- a/vissl/utils/instance_retrieval_utils/data_util.py
+++ b/vissl/utils/instance_retrieval_utils/data_util.py
@@ -14,6 +14,7 @@ from fvcore.common.file_io import PathManager
 from PIL import Image, ImageFile
 from torch.nn import functional as F
 from torchvision import transforms
+
 from vissl.utils.instance_retrieval_utils.evaluate import (
     compute_map,
     score_ap_from_ranks_1,

--- a/vissl/utils/instance_retrieval_utils/pca.py
+++ b/vissl/utils/instance_retrieval_utils/pca.py
@@ -4,6 +4,7 @@ import logging
 
 import numpy as np
 import torch
+
 from vissl.utils.io import load_file, save_file
 
 

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import numpy as np
 from fvcore.common.download import download
 from fvcore.common.file_io import PathManager, file_lock
+
 from vissl.utils.slurm import get_slurm_dir
 
 

--- a/vissl/utils/logger.py
+++ b/vissl/utils/logger.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 from fvcore.common.file_io import PathManager
+
 from vissl.utils.io import makedir
 
 

--- a/vissl/utils/misc.py
+++ b/vissl/utils/misc.py
@@ -9,6 +9,7 @@ import pkg_resources
 import torch
 import torch.multiprocessing as mp
 from scipy.sparse import csr_matrix
+
 from vissl.utils.io import load_file
 
 

--- a/vissl/utils/svm_utils/svm_low_shot_trainer.py
+++ b/vissl/utils/svm_utils/svm_low_shot_trainer.py
@@ -6,6 +6,7 @@ import pickle
 import numpy as np
 from fvcore.common.file_io import PathManager
 from sklearn.svm import LinearSVC
+
 from vissl.utils.io import load_file, save_file
 from vissl.utils.svm_utils.evaluate import get_precision_recall
 from vissl.utils.svm_utils.svm_trainer import SVMTrainer

--- a/vissl/utils/svm_utils/svm_trainer.py
+++ b/vissl/utils/svm_utils/svm_trainer.py
@@ -8,6 +8,7 @@ import numpy as np
 from fvcore.common.file_io import PathManager
 from sklearn.model_selection import cross_val_score
 from sklearn.svm import LinearSVC
+
 from vissl.utils.io import load_file, save_file
 from vissl.utils.svm_utils.evaluate import get_precision_recall
 

--- a/vissl/utils/tensorboard.py
+++ b/vissl/utils/tensorboard.py
@@ -60,6 +60,7 @@ def get_tensorboard_hook(cfg):
         SSLTensorboardHook (function): the tensorboard hook constructed
     """
     from torch.utils.tensorboard import SummaryWriter
+
     from vissl.hooks import SSLTensorboardHook
 
     # get the tensorboard directory and check tensorboard is installed


### PR DESCRIPTION
Our MLH team had issues committing files using the existing pre-commit hooks so I updated to `isort==5.7.0`, which no longer requires `seed-isort-config` and provides its own pre-commit hook. Once modified, the changes were run through `dev/linter.sh` which updated many of the older files that had been silently breaking the rules enforced for new files.

The most pertinent changes between `isort` 4 and 5 are listed below:

1. Only Python 3.6 is supported (this is okay, VISSL is 3.6 minimum anyways)
2. Command line options like `-sp` have been renamed to `--sp` to be less ambiguous
3. `isort` will not do anything by default. This has been remedied by specifying that it should check `"${DIR}"` in `dev/linter.sh`

After merging, contributors will need to reinstall the pre-commit hooks via `pre-commit install`.