### PR TITLE
Make opencv an optional dependency in VISSL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ At a high level, project requires following system dependencies.
 - PyTorch>=1.4
 - torchvision (matching PyTorch install)
 - CUDA (must be a version supported by the pytorch version)
-- OpenCV
+- OpenCV (optional)
 
 ## Installing VISSL from pre-built binaries
 
@@ -124,7 +124,7 @@ pip install classy-vision@https://github.com/facebookresearch/ClassyVision/tarba
 # install vissl dev mode (e stands for editable)
 pip install -e .[dev]
 # verify installation
-python -c 'import vissl, apex, cv2'
+python -c 'import vissl, apex'
 ```
 
 ### Install from source in Conda environment

--- a/dev/packaging/vissl_conda/vissl/meta.yaml
+++ b/dev/packaging/vissl_conda/vissl/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - apex
     - torchvision>=0.5
     - tensorboard>=1.15
-    - opencv
     - scipy
     - scikit-learn
     - parameterized

--- a/dev/packaging/vissl_pip/test/test.sh
+++ b/dev/packaging/vissl_pip/test/test.sh
@@ -14,7 +14,7 @@ conda install -y -c pytorch pytorch=1.5.1 cudatoolkit=10.1 torchvision
 pip install apex -f https://dl.fbaipublicfiles.com/vissl/packaging/apexwheels/py37_cu101_pyt151/download.html
 #pip install vissl --no-index -f https://dl.fbaipublicfiles.com/vissl/packaging/visslwheels/download.html
 pip install vissl
-python -c "import vissl, apex, cv2"
+python -c "import vissl, apex"
 cd loc1
 python -m unittest discover -v -s tests
 dev/run_quick_tests.sh

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,7 @@ At a high level, project requires following system dependencies.
 - PyTorch>=1.4
 - torchvision (matching PyTorch install)
 - CUDA (must be a version supported by the pytorch version)
-- OpenCV
+- OpenCV (optional)
 
 Installing VISSL from pre-built binaries
 -------------------------------------------

--- a/vissl/data/ssl_transforms/img_pil_to_lab_tensor.py
+++ b/vissl/data/ssl_transforms/img_pil_to_lab_tensor.py
@@ -2,11 +2,11 @@
 
 from typing import Any, Dict
 
-import cv2
 import numpy as np
 import torch
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+from vissl.utils.misc import is_opencv_available
 
 
 @register_transform("ImgPil2LabTensor")
@@ -39,6 +39,12 @@ class ImgPil2LabTensor(ClassyTransform):
         return img_lab_tensor
 
     def _convertbgr2lab(self, img):
+        # opencv is not a hard dependency for VISSL so we do the import locally
+        assert (
+            is_opencv_available()
+        ), "Please install OpenCV using: pip install opencv-python"
+        import cv2
+
         # img is [0, 255] , HWC, BGR format, uint8 type
         assert len(img.shape) == 3, "Image should have dim H x W x 3"
         assert img.shape[2] == 3, "Image should have dim H x W x 3"

--- a/vissl/utils/misc.py
+++ b/vissl/utils/misc.py
@@ -26,6 +26,22 @@ def is_fairscale_sharded_available():
     return fairscale_sharded_available
 
 
+def is_opencv_available():
+    """
+    Check if opencv is available with simple python imports.
+
+    To install opencv, simply do: `pip install opencv-python`
+    regardless of whether using conda or pip environment.
+    """
+    try:
+        import cv2  # NOQA
+
+        opencv_available = True
+    except ImportError:
+        opencv_available = False
+    return opencv_available
+
+
 def is_apex_available():
     """
     Check if apex is available with simple python imports.


### PR DESCRIPTION
Summary: Making opencv optional as it complicates the conda packaging for vissl. we use OpenCV in only 1 transform for colorization and ask user to install opencv following `pip install opencv-python` manually. When user installs VISSL from source, the instruction is already included as part of the instruction.

Differential Revision: D26724383

