### PR TITLE
Make faiss an optional dependency of VISSL and switch to faiss-gpu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ At a high level, project requires following system dependencies.
 - PyTorch>=1.4
 - torchvision (matching PyTorch install)
 - CUDA (must be a version supported by the pytorch version)
-- OpenCV
+- OpenCV (optional)
 
 ## Installing VISSL from pre-built binaries
 
@@ -124,7 +124,7 @@ pip install classy-vision@https://github.com/facebookresearch/ClassyVision/tarba
 # install vissl dev mode (e stands for editable)
 pip install -e .[dev]
 # verify installation
-python -c 'import vissl, apex, cv2'
+python -c 'import vissl, apex'
 ```
 
 ### Install from source in Conda environment

--- a/dev/packaging/vissl_conda/vissl/meta.yaml
+++ b/dev/packaging/vissl_conda/vissl/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - scikit-learn
     - parameterized
     - numpy >=1.11
-    - faiss
+    - faiss-gpu
     - fvcore
     - iopath
     - importlib_resources

--- a/dev/packaging/vissl_conda/vissl/meta.yaml
+++ b/dev/packaging/vissl_conda/vissl/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - apex
     - torchvision>=0.5
     - tensorboard>=1.15
-    - opencv
     - scipy
     - scikit-learn
     - parameterized

--- a/dev/packaging/vissl_pip/test/test.sh
+++ b/dev/packaging/vissl_pip/test/test.sh
@@ -14,7 +14,7 @@ conda install -y -c pytorch pytorch=1.5.1 cudatoolkit=10.1 torchvision
 pip install apex -f https://dl.fbaipublicfiles.com/vissl/packaging/apexwheels/py37_cu101_pyt151/download.html
 #pip install vissl --no-index -f https://dl.fbaipublicfiles.com/vissl/packaging/visslwheels/download.html
 pip install vissl
-python -c "import vissl, apex, cv2"
+python -c "import vissl, apex"
 cd loc1
 python -m unittest discover -v -s tests
 dev/run_quick_tests.sh

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ mock
 opencv-python
 tensorboard==1.15.0
 hydra-core>=1.0
-faiss>=1.5.3
+faiss-gpu
 cython
 scikit-learn
 parameterized==0.7.4

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,7 @@ At a high level, project requires following system dependencies.
 - PyTorch>=1.4
 - torchvision (matching PyTorch install)
 - CUDA (must be a version supported by the pytorch version)
-- OpenCV
+- OpenCV (optional)
 
 Installing VISSL from pre-built binaries
 -------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 tensorboard==1.15.0
 hydra-core>=1.0
-faiss>=1.5.3
 cython
 scikit-learn
 parameterized==0.7.4

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             "pre-commit",
             "nbconvert",
             "bs4",
+            "faiss-gpu",
         ]
     },
 )

--- a/tools/cluster_features_and_label.py
+++ b/tools/cluster_features_and_label.py
@@ -10,7 +10,6 @@ import sys
 from argparse import Namespace
 from typing import Any, List
 
-import faiss
 import numpy as np
 from hydra.experimental import compose, initialize_config_module
 from vissl.data import build_dataset
@@ -21,7 +20,7 @@ from vissl.utils.env import set_env_vars
 from vissl.utils.hydra_config import AttrDict, convert_to_attrdict, is_hydra_available
 from vissl.utils.io import save_file
 from vissl.utils.logger import setup_logging, shutdown_logging
-from vissl.utils.misc import merge_features, set_seeds
+from vissl.utils.misc import merge_features, set_seeds, is_faiss_available
 
 
 def get_data_features_and_images(cfg: AttrDict):
@@ -45,6 +44,13 @@ def get_data_features_and_images(cfg: AttrDict):
 
 
 def cluster_features_and_label(args: Namespace, cfg: AttrDict):
+    # faiss is an optional dependency for VISSL.
+    assert is_faiss_available(), (
+        "Please install faiss using conda install faiss-gpu -c pytorch "
+        "if using conda or pip install faiss-gpu"
+    )
+    import faiss
+
     cluster_backend = cfg.CLUSTERFIT.CLUSTER_BACKEND
     num_clusters = cfg.CLUSTERFIT.NUM_CLUSTERS
     data_split = cfg.CLUSTERFIT.FEATURES.DATA_PARTITION

--- a/vissl/data/datasets/coco.py
+++ b/vissl/data/datasets/coco.py
@@ -53,6 +53,7 @@ def get_valid_objs(entry, objs):
 
 
 def get_coco_imgs_labels_info(split, data_source_dir, args):
+    # pycocotools is an optional dependency for VISSL
     from pycocotools.coco import COCO
 
     json_file = f"{data_source_dir}/annotations/instances_{split}2014.json"

--- a/vissl/data/ssl_transforms/img_pil_to_lab_tensor.py
+++ b/vissl/data/ssl_transforms/img_pil_to_lab_tensor.py
@@ -2,11 +2,11 @@
 
 from typing import Any, Dict
 
-import cv2
 import numpy as np
 import torch
 from classy_vision.dataset.transforms import register_transform
 from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+from vissl.utils.misc import is_opencv_available
 
 
 @register_transform("ImgPil2LabTensor")
@@ -39,6 +39,12 @@ class ImgPil2LabTensor(ClassyTransform):
         return img_lab_tensor
 
     def _convertbgr2lab(self, img):
+        # opencv is not a hard dependency for VISSL so we do the import locally
+        assert (
+            is_opencv_available()
+        ), "Please install OpenCV using: pip install opencv-python"
+        import cv2
+
         # img is [0, 255] , HWC, BGR format, uint8 type
         assert len(img.shape) == 3, "Image should have dim H x W x 3"
         assert img.shape[2] == 3, "Image should have dim H x W x 3"

--- a/vissl/utils/misc.py
+++ b/vissl/utils/misc.py
@@ -26,6 +26,22 @@ def is_fairscale_sharded_available():
     return fairscale_sharded_available
 
 
+def is_opencv_available():
+    """
+    Check if opencv is available with simple python imports.
+
+    To install opencv, simply do: `pip install opencv-python`
+    regardless of whether using conda or pip environment.
+    """
+    try:
+        import cv2  # NOQA
+
+        opencv_available = True
+    except ImportError:
+        opencv_available = False
+    return opencv_available
+
+
 def is_apex_available():
     """
     Check if apex is available with simple python imports.

--- a/vissl/utils/misc.py
+++ b/vissl/utils/misc.py
@@ -26,6 +26,23 @@ def is_fairscale_sharded_available():
     return fairscale_sharded_available
 
 
+def is_faiss_available():
+    """
+    Check if faiss is available with simple python imports.
+
+    To install faiss, simply do:
+        If using PIP env: `pip install faiss-gpu`
+        If using conda env: `conda install faiss-gpu -c pytorch`
+    """
+    try:
+        import faiss  # NOQA
+
+        faiss_available = True
+    except ImportError:
+        faiss_available = False
+    return faiss_available
+
+
 def is_opencv_available():
     """
     Check if opencv is available with simple python imports.


### PR DESCRIPTION
Summary:
- making faiss an optional dependency. faiss is used only in 1 place in VISSL for clusterfit.
- When user uses clusterfit, we check if faiss is installed or not. we give instructions to user at runtime to how to install faiss if not already done
- we shift to using faiss-gpu since that's official dependency to use for faiss

Differential Revision: D26725011

