### PR TITLE
dependencies for conda package testing

### DIFF
--- a/dev/packaging/vissl_conda/build_conda.sh
+++ b/dev/packaging/vissl_conda/build_conda.sh
@@ -13,5 +13,6 @@ export BUILD_VERSION=$build_version
 
 # We allow the vissl channel to get the apex package.
 # We specify it with a full url to avoid a name clash with a local directory called vissl.
-# Having defaults before conda is so that the tensorboard used in the tests will work
+# Having defaults before conda-forge is so that the tensorboard used in the
+# tests will work.
 conda build -c https://conda.anaconda.org/vissl -c iopath -c pytorch -c defaults -c conda-forge --no-anaconda-upload --python "$PYTHON_VERSION" --output-folder "$packaging/out" "$packaging/vissl"

--- a/dev/packaging/vissl_conda/build_conda.sh
+++ b/dev/packaging/vissl_conda/build_conda.sh
@@ -13,4 +13,5 @@ export BUILD_VERSION=$build_version
 
 # We allow the vissl channel to get the apex package.
 # We specify it with a full url to avoid a name clash with a local directory called vissl.
-conda build -c https://conda.anaconda.org/vissl -c iopath -c conda-forge -c pytorch -c defaults --no-anaconda-upload --python "$PYTHON_VERSION" --output-folder "$packaging/out" "$packaging/vissl"
+# Having defaults before conda is so that the tensorboard used in the tests will work
+conda build -c https://conda.anaconda.org/vissl -c iopath -c pytorch -c defaults -c conda-forge --no-anaconda-upload --python "$PYTHON_VERSION" --output-folder "$packaging/out" "$packaging/vissl"

--- a/dev/packaging/vissl_conda/vissl/meta.yaml
+++ b/dev/packaging/vissl_conda/vissl/meta.yaml
@@ -43,6 +43,8 @@ test:
   requires:
     - ca-certificates
     - cudatoolkit=10.1
+    - opencv
+    - tensorboard
   commands:
     - python -m unittest discover -v -s tests
     - ./dev/run_quick_tests.sh


### PR DESCRIPTION
Now opencv and tensorboard are not official dependencies, make sure they are available for the conda tests. This is part of the followup to #198 (conda not installing nicely), specifically PRs #202 and #205 which removed them as deps.