### PR TITLE
[fix] configuration for low_shot experiments for which the transformation pipeline has 2 consecutive resize

### DIFF
--- a/configs/config/benchmark/low_shot_classification/places205/eval_resnet_8gpu_transfer_places205_low_shot_svm.yaml
+++ b/configs/config/benchmark/low_shot_classification/places205/eval_resnet_8gpu_transfer_places205_low_shot_svm.yaml
@@ -9,8 +9,6 @@ config:
       BATCHSIZE_PER_REPLICA: 32
       TRANSFORMS:
         - name: Resize
-          size: 256
-        - name: Resize
           size: [224, 224]
         - name: ToTensor
         - name: Normalize
@@ -24,8 +22,6 @@ config:
       DATASET_NAMES: [places205_everstore]
       BATCHSIZE_PER_REPLICA: 32
       TRANSFORMS:
-        - name: Resize
-          size: 256
         - name: Resize
           size: [224, 224]
         - name: ToTensor

--- a/configs/config/benchmark/low_shot_classification/voc07/eval_resnet_8gpu_transfer_voc07_low_shot_svm.yaml
+++ b/configs/config/benchmark/low_shot_classification/voc07/eval_resnet_8gpu_transfer_voc07_low_shot_svm.yaml
@@ -9,8 +9,6 @@ config:
       BATCHSIZE_PER_REPLICA: 32
       TRANSFORMS:
         - name: Resize
-          size: 256
-        - name: Resize
           size: [224, 224]
         - name: ToTensor
         - name: Normalize
@@ -25,8 +23,6 @@ config:
       DATASET_NAMES: [voc2007]
       BATCHSIZE_PER_REPLICA: 32
       TRANSFORMS:
-        - name: Resize
-          size: 256
         - name: Resize
           size: [224, 224]
         - name: ToTensor


### PR DESCRIPTION
This is a rather simplification: two resize consecutive to each other can be merged into one single.

I tested that there are no side effects from that: the two pipelines (before and after simplification) lead to the same output vector.