### PR TITLE
[Proposal] Improve the DATA_LIMIT atribute to be able to handle more uses cases

### DIFF
--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-import numpy as np
 import unittest
 
-from vissl.data.data_helper import unbalanced_sub_sampling, balanced_sub_sampling
+import numpy as np
+from vissl.data.data_helper import balanced_sub_sampling, unbalanced_sub_sampling
 
 
 class TestDataLimitSubSampling(unittest.TestCase):

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -1,0 +1,40 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import numpy as np
+import unittest
+
+from vissl.data.data_helper import unbalanced_sub_sampling, balanced_sub_sampling
+
+
+class TestDataLimitSubSampling(unittest.TestCase):
+    """
+    Testing the DATA_LIMIT underlying sub sampling methods
+    """
+
+    def test_unbalanced_sub_sampling(self):
+        labels = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0])
+
+        indices1 = unbalanced_sub_sampling(len(labels), nb_samples=8, skip_samples=0)
+        self.assertEqual(8, len(indices1))
+        self.assertEqual(len(indices1), len(set(indices1)), "indices must be unique")
+
+        indices2 = unbalanced_sub_sampling(len(labels), nb_samples=8, skip_samples=2)
+        self.assertEqual(8, len(indices2))
+        self.assertEqual(len(indices2), len(set(indices2)), "indices must be unique")
+
+        self.assertTrue(np.array_equal(indices1[2:], indices2[:-2]), "skipping samples should slide the window")
+
+    def test_balanced_sub_sampling(self):
+        labels = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0])
+        unique_labels = set(labels)
+
+        indices1 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=0)
+        values, counts = np.unique(labels[indices1], return_counts=True)
+        self.assertEqual(8, len(indices1))
+        self.assertEqual(set(values), set(unique_labels), "at least one of each label should be selected")
+        self.assertEqual(2, np.min(counts), "at least two of each label is selected")
+        self.assertEqual(2, np.max(counts), "at most two of each label is selected")
+
+        indices2 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=4)
+        self.assertEqual(8, len(indices2))
+        self.assertEqual(4, len(set(indices1) & set(indices2)), "skipping samples should slide the window")

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -22,7 +22,10 @@ class TestDataLimitSubSampling(unittest.TestCase):
         self.assertEqual(8, len(indices2))
         self.assertEqual(len(indices2), len(set(indices2)), "indices must be unique")
 
-        self.assertTrue(np.array_equal(indices1[2:], indices2[:-2]), "skipping samples should slide the window")
+        self.assertTrue(
+            np.array_equal(indices1[2:], indices2[:-2]),
+            "skipping samples should slide the window",
+        )
 
     def test_balanced_sub_sampling(self):
         labels = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0])
@@ -31,10 +34,18 @@ class TestDataLimitSubSampling(unittest.TestCase):
         indices1 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=0)
         values, counts = np.unique(labels[indices1], return_counts=True)
         self.assertEqual(8, len(indices1))
-        self.assertEqual(set(values), set(unique_labels), "at least one of each label should be selected")
+        self.assertEqual(
+            set(values),
+            set(unique_labels),
+            "at least one of each label should be selected",
+        )
         self.assertEqual(2, np.min(counts), "at least two of each label is selected")
         self.assertEqual(2, np.max(counts), "at most two of each label is selected")
 
         indices2 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=4)
         self.assertEqual(8, len(indices2))
-        self.assertEqual(4, len(set(indices1) & set(indices2)), "skipping samples should slide the window")
+        self.assertEqual(
+            4,
+            len(set(indices1) & set(indices2)),
+            "skipping samples should slide the window",
+        )

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -14,11 +14,11 @@ class TestDataLimitSubSampling(unittest.TestCase):
     def test_unbalanced_sub_sampling(self):
         labels = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0])
 
-        indices1 = unbalanced_sub_sampling(len(labels), nb_samples=8, skip_samples=0)
+        indices1 = unbalanced_sub_sampling(len(labels), num_samples=8, skip_samples=0)
         self.assertEqual(8, len(indices1))
         self.assertEqual(len(indices1), len(set(indices1)), "indices must be unique")
 
-        indices2 = unbalanced_sub_sampling(len(labels), nb_samples=8, skip_samples=2)
+        indices2 = unbalanced_sub_sampling(len(labels), num_samples=8, skip_samples=2)
         self.assertEqual(8, len(indices2))
         self.assertEqual(len(indices2), len(set(indices2)), "indices must be unique")
 
@@ -31,7 +31,7 @@ class TestDataLimitSubSampling(unittest.TestCase):
         labels = np.array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0])
         unique_labels = set(labels)
 
-        indices1 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=0)
+        indices1 = balanced_sub_sampling(labels, num_samples=8, skip_samples=0)
         values, counts = np.unique(labels[indices1], return_counts=True)
         self.assertEqual(8, len(indices1))
         self.assertEqual(
@@ -42,7 +42,7 @@ class TestDataLimitSubSampling(unittest.TestCase):
         self.assertEqual(2, np.min(counts), "at least two of each label is selected")
         self.assertEqual(2, np.max(counts), "at most two of each label is selected")
 
-        indices2 = balanced_sub_sampling(labels, nb_samples=8, skip_samples=4)
+        indices2 = balanced_sub_sampling(labels, num_samples=8, skip_samples=4)
         self.assertEqual(8, len(indices2))
         self.assertEqual(
             4,

--- a/tools/perf_measurement/README.md
+++ b/tools/perf_measurement/README.md
@@ -11,7 +11,7 @@ buck run @mode/opt deeplearning/projects/ssl_framework/tools/perf_measurement:be
     config=test/integration_test/quick_simclr \
     config.DATA.TRAIN.DATA_SOURCES=[disk_folder] \
     config.DATA.TRAIN.DATASET_NAMES=[imagenet1k_folder] \
-    config.DATA.TRAIN.DATA_LIMIT=-1 \
+    config.DATA.TRAIN.DATA_LIMIT.NUM_SAMPLES=-1 \
     config.DATA.NUM_DATALOADER_WORKERS=10 \
     config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=64
 ```

--- a/tools/perf_measurement/README.md
+++ b/tools/perf_measurement/README.md
@@ -11,7 +11,7 @@ buck run @mode/opt deeplearning/projects/ssl_framework/tools/perf_measurement:be
     config=test/integration_test/quick_simclr \
     config.DATA.TRAIN.DATA_SOURCES=[disk_folder] \
     config.DATA.TRAIN.DATASET_NAMES=[imagenet1k_folder] \
-    config.DATA.TRAIN.DATA_LIMIT.NUM_SAMPLES=-1 \
+    config.DATA.TRAIN.DATA_LIMIT=-1 \
     config.DATA.NUM_DATALOADER_WORKERS=10 \
     config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=64
 ```

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -250,8 +250,26 @@ config:
       # accomodate the smoothed labels. See
       # LOSS.cross_entropy_multiple_output_single_target for more information.
       #
-      # limit the amount of data used in training. If set to -1, full dataset is used.
+      # Limit the amount of data used in training by specifying a range of type "start + number of elements":
+      #   DATA_LIMIT: N      -1 means that the range will extend to the end, otherwise sample N elements
+      #   DATA_LIMIT_SKIP: S  0 means that the range will start from the Sth element, effectively removing S element
+      #   DATA_LIMIT_SAMPLING:
+      #     SEED: 0           specifies the seed used to sample these elements from the full dataset
+      #     BALANCED: False   whether or not each class should appear equally in the sample (requires labels)
+      #
+      # Example: to select a range of 500 samples for validation, skipping the first 1000 samples (say these are
+      # already used in the training split) and sub-sampling these elements such that each class appears equally:
+      # DATA_LIMIT: 500
+      # DATA_LIMIT_SKIP: 1000
+      # DATA_LIMIT_SAMPLING:
+      #   SEED: 0
+      #   BALANCED: True
       DATA_LIMIT: -1
+      DATA_LIMIT_SKIP: 0
+      DATA_LIMIT_SAMPLING:
+        SEED: 0
+        BALANCED: False
+
       # whether the data specified (whether file list or directory) should be copied locally
       # on the machine where training is happening.
       COPY_TO_LOCAL_DISK: False
@@ -286,6 +304,10 @@ config:
       COLLATE_FUNCTION: "default_collate"
       COLLATE_FUNCTION_PARAMS: {}
       DATA_LIMIT: -1
+      DATA_LIMIT_SKIP: 0
+      DATA_LIMIT_SAMPLING:
+        SEED: 0
+        BALANCED: False
       DATASET_NAMES: ["imagenet1k_folder"]
       COPY_TO_LOCAL_DISK: False
       COPY_DESTINATION_DIR: ""

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -250,25 +250,24 @@ config:
       # accomodate the smoothed labels. See
       # LOSS.cross_entropy_multiple_output_single_target for more information.
       #
-      # Limit the amount of data used in training by specifying a range of type "start + number of elements":
-      #   DATA_LIMIT: N      -1 means that the range will extend to the end, otherwise sample N elements
-      #   DATA_LIMIT_SKIP: S  0 means that the range will start from the Sth element, effectively removing S element
-      #   DATA_LIMIT_SAMPLING:
-      #     SEED: 0           specifies the seed used to sample these elements from the full dataset
-      #     BALANCED: False   whether or not each class should appear equally in the sample (requires labels)
+      # Limit the amount of data used in training. If set to -1, full dataset is used.
+      #
+      DATA_LIMIT: -1
+      #
+      # Specifies how the DATA_LIMIT samples are sampled
       #
       # Example: to select a range of 500 samples for validation, skipping the first 1000 samples (say these are
       # already used in the training split) and sub-sampling these elements such that each class appears equally:
       # DATA_LIMIT: 500
-      # DATA_LIMIT_SKIP: 1000
       # DATA_LIMIT_SAMPLING:
       #   SEED: 0
       #   BALANCED: True
-      DATA_LIMIT: -1
-      DATA_LIMIT_SKIP: 0
+      #   SKIP: 1000
+      #
       DATA_LIMIT_SAMPLING:
         SEED: 0
         BALANCED: False
+        SKIP: 0
 
       # whether the data specified (whether file list or directory) should be copied locally
       # on the machine where training is happening.
@@ -304,10 +303,10 @@ config:
       COLLATE_FUNCTION: "default_collate"
       COLLATE_FUNCTION_PARAMS: {}
       DATA_LIMIT: -1
-      DATA_LIMIT_SKIP: 0
       DATA_LIMIT_SAMPLING:
         SEED: 0
         BALANCED: False
+        SKIP: 0
       DATASET_NAMES: ["imagenet1k_folder"]
       COPY_TO_LOCAL_DISK: False
       COPY_DESTINATION_DIR: ""

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -261,12 +261,12 @@ config:
       # DATA_LIMIT: 500
       # DATA_LIMIT_SAMPLING:
       #   SEED: 0
-      #   BALANCED: True
-      #   SKIP: 1000
+      #   IS_BALANCED: True
+      #   SKIP_NUM_SAMPLES: 1000
       #
       DATA_LIMIT_SAMPLING:
         SEED: 0
-        BALANCED: False
+        IS_BALANCED: False
         SKIP_NUM_SAMPLES: 0
 
       # whether the data specified (whether file list or directory) should be copied locally
@@ -305,8 +305,8 @@ config:
       DATA_LIMIT: -1
       DATA_LIMIT_SAMPLING:
         SEED: 0
-        BALANCED: False
-        SKIP: 0
+        IS_BALANCED: False
+        SKIP_NUM_SAMPLES: 0
       DATASET_NAMES: ["imagenet1k_folder"]
       COPY_TO_LOCAL_DISK: False
       COPY_DESTINATION_DIR: ""

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -267,7 +267,7 @@ config:
       DATA_LIMIT_SAMPLING:
         SEED: 0
         BALANCED: False
-        SKIP: 0
+        SKIP_NUM_SAMPLES: 0
 
       # whether the data specified (whether file list or directory) should be copied locally
       # on the machine where training is happening.

--- a/vissl/data/data_helper.py
+++ b/vissl/data/data_helper.py
@@ -36,17 +36,23 @@ def with_temporary_numpy_seed(seed: int):
     np.random.set_state(random_state)
 
 
-def unbalanced_sub_sampling(total_size: int, nb_samples: int, skip_samples: int = 0, seed: int = 0) -> np.ndarray:
+def unbalanced_sub_sampling(
+    total_size: int, nb_samples: int, skip_samples: int = 0, seed: int = 0
+) -> np.ndarray:
     """
     Given an original dataset of size 'total_size', sub_sample part of the dataset such that
     the sub sampling is deterministic (identical across distributed workers)
     Return the selected indices
     """
     with with_temporary_numpy_seed(seed):
-        return np.random.choice(total_size, size=skip_samples+nb_samples, replace=False)[skip_samples:]
+        return np.random.choice(
+            total_size, size=skip_samples + nb_samples, replace=False
+        )[skip_samples:]
 
 
-def balanced_sub_sampling(labels: np.ndarray, nb_samples: int, skip_samples: int = 0, seed: int = 0) -> np.ndarray:
+def balanced_sub_sampling(
+    labels: np.ndarray, nb_samples: int, skip_samples: int = 0, seed: int = 0
+) -> np.ndarray:
     """
     Given some labels, sub_sample a part of the labels such that:
     - the number of samples of each label differs by at most one
@@ -60,14 +66,18 @@ def balanced_sub_sampling(labels: np.ndarray, nb_samples: int, skip_samples: int
     unique_labels = sorted(groups.keys())
     sq, sr = divmod(skip_samples, len(unique_labels))
     q, r = divmod(nb_samples, len(unique_labels))
-    assert q > 0, "the number of samples should be at least equal to the number of classes"
+    assert (
+        q > 0
+    ), "the number of samples should be at least equal to the number of classes"
 
     with with_temporary_numpy_seed(seed):
         for i, label in enumerate(unique_labels):
             label_indices = groups[label]
             nb_label_samples = q + (1 if i < r else 0)
             skip_label_samples = sq + (1 if i < sr else 0)
-            permuted_indices = np.random.choice(label_indices, size=skip_label_samples+nb_label_samples, replace=False)
+            permuted_indices = np.random.choice(
+                label_indices, size=skip_label_samples + nb_label_samples, replace=False
+            )
             groups[label] = permuted_indices[skip_label_samples:]
 
     return np.concatenate([groups[label] for label in unique_labels])

--- a/vissl/data/data_helper.py
+++ b/vissl/data/data_helper.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
+import contextlib
 import logging
 import queue
 
@@ -22,6 +22,55 @@ def get_mean_image(crop_size):
     """
     img = Image.fromarray(128 * np.ones((crop_size, crop_size, 3), dtype=np.uint8))
     return img
+
+
+@contextlib.contextmanager
+def with_temporary_numpy_seed(seed: int):
+    """
+    Context manager to run a specific portion of code with a given seed:
+    resumes the numpy state after the execution of the block
+    """
+    random_state = np.random.get_state()
+    np.random.seed(seed)
+    yield
+    np.random.set_state(random_state)
+
+
+def unbalanced_sub_sampling(total_size: int, nb_samples: int, skip_samples: int = 0, seed: int = 0) -> np.ndarray:
+    """
+    Given an original dataset of size 'total_size', sub_sample part of the dataset such that
+    the sub sampling is deterministic (identical across distributed workers)
+    Return the selected indices
+    """
+    with with_temporary_numpy_seed(seed):
+        return np.random.choice(total_size, size=skip_samples+nb_samples, replace=False)[skip_samples:]
+
+
+def balanced_sub_sampling(labels: np.ndarray, nb_samples: int, skip_samples: int = 0, seed: int = 0) -> np.ndarray:
+    """
+    Given some labels, sub_sample a part of the labels such that:
+    - the number of samples of each label differs by at most one
+    - the sub sampling is deterministic (identical across distributed workers)
+    Return the selected indices
+    """
+    groups = {}
+    for i, label in enumerate(labels):
+        groups.setdefault(label, []).append(i)
+
+    unique_labels = sorted(groups.keys())
+    sq, sr = divmod(skip_samples, len(unique_labels))
+    q, r = divmod(nb_samples, len(unique_labels))
+    assert q > 0, "the number of samples should be at least equal to the number of classes"
+
+    with with_temporary_numpy_seed(seed):
+        for i, label in enumerate(unique_labels):
+            label_indices = groups[label]
+            nb_label_samples = q + (1 if i < r else 0)
+            skip_label_samples = sq + (1 if i < sr else 0)
+            permuted_indices = np.random.choice(label_indices, size=skip_label_samples+nb_label_samples, replace=False)
+            groups[label] = permuted_indices[skip_label_samples:]
+
+    return np.concatenate([groups[label] for label in unique_labels])
 
 
 class StatefulDistributedSampler(DistributedSampler):
@@ -70,7 +119,7 @@ class StatefulDistributedSampler(DistributedSampler):
         assert self.batch_size > 0, "batch_size not set for the sampler"
 
         # resume the sampler
-        indices = indices[(self.start_iter * self.batch_size) :]
+        indices = indices[(self.start_iter * self.batch_size):]
         return iter(indices)
 
     def set_start_iter(self, start_iter):

--- a/vissl/data/data_helper.py
+++ b/vissl/data/data_helper.py
@@ -129,7 +129,8 @@ class StatefulDistributedSampler(DistributedSampler):
         assert self.batch_size > 0, "batch_size not set for the sampler"
 
         # resume the sampler
-        indices = indices[(self.start_iter * self.batch_size):]
+        start_index = self.start_iter * self.batch_size
+        indices = indices[start_index:]
         return iter(indices)
 
     def set_start_iter(self, start_iter):

--- a/vissl/data/disk_dataset.py
+++ b/vissl/data/disk_dataset.py
@@ -87,13 +87,6 @@ class DiskImageDataset(QueueDataset):
             # Avoid creating it over and over again.
             self.is_initialized = True
 
-        if self.cfg["DATA"][self.split]["DATA_LIMIT"] > 0:
-            limit = self.cfg["DATA"][self.split]["DATA_LIMIT"]
-            if self.data_source == "disk_filelist":
-                self.image_dataset = self.image_dataset[:limit]
-            elif self.data_source == "disk_folder":
-                self.image_dataset.samples = self.image_dataset.samples[:limit]
-
     def num_samples(self):
         """
         Size of the dataset

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -76,7 +76,6 @@ class GenericSSLDataset(Dataset):
         self.dataset_names = self.cfg["DATA"][split].DATASET_NAMES
         self.label_type = self.cfg["DATA"][split].LABEL_TYPE
         self.data_limit = self.cfg["DATA"][split].DATA_LIMIT
-        self.data_limit_skip = self.cfg["DATA"][split].DATA_LIMIT_SKIP
         self.data_limit_sampling = self.cfg["DATA"][split].DATA_LIMIT_SAMPLING
         self.transform = get_transform(self.cfg["DATA"][split].TRANSFORMS)
         self._labels_init = False
@@ -234,14 +233,14 @@ class GenericSSLDataset(Dataset):
                 self.sub_set = unbalanced_sub_sampling(
                     total_size=len(self.data_objs[0]),
                     nb_samples=self.data_limit,
-                    skip_samples=self.data_limit_skip,
+                    skip_samples=self.data_limit_sampling.SKIP,
                     seed=self.data_limit_sampling.SEED,
                 )
             else:
                 self.sub_set = balanced_sub_sampling(
                     labels=self.label_objs[0],
                     nb_samples=self.data_limit,
-                    skip_samples=self.data_limit_skip,
+                    skip_samples=self.data_limit_sampling.SKIP,
                     seed=self.data_limit_sampling.SEED,
                 )
             self._subset_initialized = True

--- a/vissl/data/synthetic_dataset.py
+++ b/vissl/data/synthetic_dataset.py
@@ -19,15 +19,16 @@ class SyntheticImageDataset(Dataset):
         data_source (string, Optional): data source ("synthetic") [not used]
     """
 
-    def __init__(self, cfg, path, split, dataset_name, data_source="synthetic"):
+    DEFAULT_SIZE = 50_000
+
+    def __init__(
+        self, cfg, path: str, split: str, dataset_name: str, data_source="synthetic"
+    ):
         super(SyntheticImageDataset, self).__init__()
         self.cfg = cfg
         self.split = split
         self.data_source = data_source
-        self._num_samples = 50000
-        # by default, pretend dataset size is 500 images. OR user specified limit
-        if cfg.DATA[split].DATA_LIMIT > 0:
-            self._num_samples = cfg.DATA[split].DATA_LIMIT
+        self._num_samples = max(self.DEFAULT_SIZE, cfg.DATA[split].DATA_LIMIT)
 
     def num_samples(self):
         """


### PR DESCRIPTION
This PR is a draft, pushed for visibility and discussion.

The additional uses cases I propose to support are:
- being able to sub-select part of a dataset in a balanced way (each label is included the same number of time)
- being able to sub-select exclusive parts of the same dataset (for instance to have a validation set that does not intersect with a training set, useful for HP searches)
- make sure that this sub-sampling is deterministic (same seed across all distributed workers)

This would avoid having to create sub-sets of datasets such as ImageNet to test on 1% of each label for instance. It would also allow to benchmark SSL algorithms on low data regime in a more flexible way.

/!\ This PR introduces a breaking change (DATA_LIMIT is not an integer anymore but a structure)

This PR includes:
- unit tests for the sub-sampling strategies
- update of all configuration using the DATA_LIMIT attribute