### PR TITLE
[fix] Full tuning configurations for imagenet and places205

### DIFF
--- a/configs/config/benchmark/fulltune/imagenet1k/eval_resnet_8gpu_transfer_in1k_fulltune.yaml
+++ b/configs/config/benchmark/fulltune/imagenet1k/eval_resnet_8gpu_transfer_in1k_fulltune.yaml
@@ -53,6 +53,9 @@ config:
   TRAINER:
     TRAIN_STEP_NAME: standard_train_step
   MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      EVAL_TRUNK_AND_HEAD: False
     TRUNK:
       NAME: resnet
       TRUNK_PARAMS:

--- a/configs/config/benchmark/fulltune/places205/eval_resnet_8gpu_transfer_places205_fulltune.yaml
+++ b/configs/config/benchmark/fulltune/places205/eval_resnet_8gpu_transfer_places205_fulltune.yaml
@@ -53,6 +53,9 @@ config:
   TRAINER:
     TRAIN_STEP_NAME: standard_train_step
   MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      EVAL_TRUNK_AND_HEAD: False
     TRUNK:
       NAME: resnet
       TRUNK_PARAMS:


### PR DESCRIPTION
The evaluation mode was not enabled, leading to a crash when loading the weights of a pre-trained model. The fix only consists  in enabling the evaluation.