### PR TITLE
[Proposal] [Draft] [tooling] configurable linting script

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -21,7 +21,7 @@ For every PR, we run/mandate a few checks before code is ready for review. The c
 2. **black**: We format the code using black8
 3. **isort**: We check that imports are properly sorted https://pypi.org/project/isort/. See `setup.cfg` for the settings.
 
-In order to format code before code review, there are 2 options:
+In order to format code before code review, there are several options:
 
 ### Option 1: use `dev/linter.sh`
 
@@ -33,3 +33,19 @@ We provide pre-commit hooks so as you build and commit (locally or github), the 
 You need to run `pre-commit install` once to enable this.
 
 Read the doc https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/ for how all the components operate and the pipeline/steps involved.
+
+### Option 3: use `python dev/lint_commit.py -a`
+
+This script is an improved version of `dev/linter.sh` which requires an additional dependency (`pip install gitpython`) but allows you to run the linting in a more selective manner:
+- on the full repository or just the files you modified
+- with or without auto-correction of the files
+- with selective checks only (running black only)
+
+Here are a few examples of commands showing the different options:  
+
+- `python dev/lint_commit.py --all` will run all the checks on the modified files
+- `python dev/lint_commit.py --all --check` will do the same but without auto-correction
+- `python dev/lint_commit.py --all --repo` will run all the checks on the full repository
+- `python dev/lint_commit.py --black` will run black on the modified files
+- `python dev/lint_commit.py --sort` will run isort on the modified files
+- `python dev/lint_commit.py --flake` will run flake8 on the modified files

--- a/dev/lint_commit.py
+++ b/dev/lint_commit.py
@@ -1,0 +1,171 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import argparse
+import os
+from typing import Iterable, NamedTuple, Sequence
+
+
+try:
+    from git import Repo
+except ImportError:
+    raise ValueError("This script requires gitpython: pip install gitpython")
+
+
+def get_argument_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--all", action="store_const", const=True, default=False)
+    parser.add_argument(
+        "-b", "--black", action="store_const", const=True, default=False
+    )
+    parser.add_argument(
+        "-f", "--flake", action="store_const", const=True, default=False
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_const",
+        const=True,
+        default=False,
+        help="Only check (no correction)",
+    )
+    parser.add_argument("-s", "--sort", action="store_const", const=True, default=False)
+    parser.add_argument(
+        "-r",
+        "--repo",
+        action="store_const",
+        const=True,
+        default=False,
+        help="Running the linter on the whole repository",
+    )
+    return parser
+
+
+class FileDiff(NamedTuple):
+    change_type: str
+    file_name: str
+
+
+def get_index_diff_file_names(repo_dir: str) -> Iterable[FileDiff]:
+    """
+    Return the list of file diff in the staging area (the index)
+    """
+    repo = Repo(repo_dir)
+    for file_diff in repo.head.commit.diff():
+        yield FileDiff(change_type=file_diff.change_type, file_name=file_diff.a_path)
+
+
+def get_working_diff_file_names(repo_dir: str) -> Iterable[FileDiff]:
+    """
+    Return the list of file diffs in the working tree (not added)
+    """
+    repo = Repo(repo_dir)
+    for file_diff in repo.index.diff(None):
+        yield FileDiff(change_type=file_diff.change_type, file_name=file_diff.a_path)
+    for path in repo.untracked_files:
+        yield FileDiff(change_type="A", file_name=path)
+
+
+def get_list_of_impacted_files(repo_dir: str) -> Sequence[str]:
+    """
+    Return the full list of impacted files, either in the index or the working tree,
+    combined such that deletion and renamings are ignored properly.
+    """
+    files = set()
+    for diff in get_index_diff_file_names(repo_dir):
+        if diff.change_type not in {"D", "R"}:
+            files.add(diff.file_name)
+    for diff in get_working_diff_file_names(repo_dir):
+        if diff.change_type != "D":
+            files.add(diff.file_name)
+        else:
+            files.remove(diff.file_name)
+    return list(files)
+
+
+def _run_command(command: str):
+    os.system(command)
+
+
+def _is_correct_path(path: str):
+    return os.path.isdir(path) or path.endswith(".py")
+
+
+def run_black_on(paths: Sequence[str], check_only: bool):
+    options = "--check" if check_only else ""
+    for path in paths:
+        if _is_correct_path(path):
+            _run_command(f"black --quiet {options} {path}")
+
+
+def run_sort_include_on(paths: Sequence[str], check_only: bool):
+    options = "-c" if check_only else ""
+    for path in paths:
+        if os.path.isdir(path):
+            _run_command(f"isort {options} -sp {path}")
+        elif path.endswith(".py"):
+            _run_command(f"isort {options} {path}")
+
+
+def run_flake8_on(paths: Sequence[str]):
+    for path in paths:
+        if _is_correct_path(path):
+            _run_command(
+                f"flake8 --max-line-length 88 --ignore E501,E203,E266,W503,E741 {path}"
+            )
+
+
+if __name__ == "__main__":
+    """
+    Allows to apply the linting checks in a configurable way:
+    - on the modified files only or one the full GIT repository
+    - all checks or only a selected few of them
+    - with automatic correction enabled or disabled
+
+    To perform all checks on the modified files only:
+
+    ```
+    python dev/lint_commit.py --all
+    ```
+
+    To disable the automatic correction of errors:
+
+    ```
+    python dev/lint_commit.py --all --check
+    ```
+
+    To selectively apply one check (ignoring the others):
+
+    ```
+    python dev/lint_commit.py --black
+    python dev/lint_commit.py --flake
+    python dev/lint_commit.py --sort
+    ```
+
+    To apply the checks on the whole repository:
+
+    ```
+    python dev/lint_commit.py --all --repo
+    ```
+    """
+    args = get_argument_parser().parse_args()
+
+    # Find the files and folders to impact with the checks
+    if not args.repo:
+        target_paths = get_list_of_impacted_files(os.getcwd())
+    else:
+        target_paths = [
+            "vissl",
+            "extra_scripts",
+            "tools",
+            "dev",
+            "hydra_plugins",
+            "tests",
+        ]
+
+    # Apply the checks on the files to impact
+    if args.all or args.sort:
+        run_sort_include_on(target_paths, check_only=args.check)
+    if args.all or args.black:
+        run_black_on(target_paths, check_only=args.check)
+    if args.all or args.flake:
+        run_flake8_on(target_paths)


### PR DESCRIPTION
Configurable linting script which allows to select whether or not:
- to lint for the whole repo or just the modified files
- select which type of linting to apply (useful for fixing error and skipping to the selected check)
- with option to decide for auto-correction or not

The main disadvantage of the script is that it requires an additional dependency, reason why I did not replace "linting.sh" but the counterpart is much greater flexibility.

I let you decide if this is interesting: I use it on my side, so maybe it might be useful to others, but I can definitely keep it on my side only if necessary.