### PR TITLE
[fix] If nvidia-smi returns with non zero code, log the error instead of interrupting the training

### DIFF
--- a/vissl/utils/logger.py
+++ b/vissl/utils/logger.py
@@ -82,6 +82,10 @@ def log_gpu_stats():
         logging.error(
             "Failed to find the 'nvidia-smi' executable for printing GPU stats"
         )
+    except subprocess.CalledProcessError as e:
+        logging.error(
+            f"nvidia-smi returned non zero error code: {e.returncode}"
+        )
 
 
 def print_gpu_memory_usage():


### PR DESCRIPTION
I got this error during training (nvidia-smi returning a non-zero code) leading to the termination of my training.

If this happens, I think we should definitely log the event, but not interrupt the training.

Here is a short fix to deal with this issue.