### PR TITLE
[feature] (activation stats): ability to track the statistics of each layer in the model when training

### DIFF
--- a/tests/test_activation_statistics.py
+++ b/tests/test_activation_statistics.py
@@ -1,0 +1,48 @@
+import unittest
+
+import torch
+import torchvision.models as models
+from vissl.utils.activation_statistics import (
+    ActivationStatisticsAccumulator,
+    ActivationStatisticsMonitor,
+)
+
+
+class TestDataLimitSubSampling(unittest.TestCase):
+    def test_activation_statistics(self):
+        torch.manual_seed(0)
+
+        accumulator = ActivationStatisticsAccumulator()
+        watcher = ActivationStatisticsMonitor(
+            observer=accumulator, log_frequency=1, ignored_modules=set()
+        )
+        watcher.set_iteration(1)
+        model = models.resnet18()
+        watcher.monitor(model)
+        model(torch.randn(size=(1, 3, 224, 224)))
+
+        stats = accumulator.stats
+        self.assertEqual(60, len(stats))
+        for stat in stats:
+            self.assertEqual(1, stat.iteration)
+
+        # Verify that the first statistics produced is for the first
+        # layer of the ResNet
+        first_stat = stats[0]
+        self.assertEqual("conv1", first_stat.name)
+        self.assertEqual("torch.nn.modules.conv.Conv2d", first_stat.module_type)
+        self.assertAlmostEqual(-0.0001686, first_stat.mean, delta=1e-6)
+        self.assertAlmostEqual(1.6035640, first_stat.maxi, delta=1e-6)
+        self.assertAlmostEqual(-1.4944878, first_stat.mini, delta=1e-6)
+
+        # Verify that only leaf modules have statistics
+        exported_modules_types = {
+            "torch.nn.modules.pooling.MaxPool2d",
+            "torch.nn.modules.pooling.AdaptiveAvgPool2d",
+            "torch.nn.modules.batchnorm.BatchNorm2d",
+            "torch.nn.modules.activation.ReLU",
+            "torch.nn.modules.conv.Conv2d",
+            "torch.nn.modules.linear.Linear",
+        }
+        module_types = {stat.module_type for stat in stats}
+        self.assertEqual(sorted(exported_modules_types), sorted(module_types))

--- a/tests/test_activation_statistics.py
+++ b/tests/test_activation_statistics.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 import unittest
 
 import torch

--- a/tests/test_activation_statistics.py
+++ b/tests/test_activation_statistics.py
@@ -8,7 +8,7 @@ from vissl.utils.activation_statistics import (
 )
 
 
-class TestDataLimitSubSampling(unittest.TestCase):
+class TestActivationStatisticsMonitoring(unittest.TestCase):
     def test_activation_statistics(self):
         torch.manual_seed(0)
 

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -137,6 +137,15 @@ config:
       LOG_PARAMS_EVERY_N_ITERS: 310
 
   # ----------------------------------------------------------------------------------- #
+  # MONITORING
+  # ----------------------------------------------------------------------------------- #
+  MONITORING:
+    # At which frequency do we monitor statistics on the activations:
+    # - 0 means that we do not monitor statistics
+    # - N > 0 means we monitor every N iterations
+    MONITOR_ACTIVATION_STATISTICS: 0
+
+  # ----------------------------------------------------------------------------------- #
   # DATA
   # ----------------------------------------------------------------------------------- #
   DATA:

--- a/vissl/hooks/tensorboard_hook.py
+++ b/vissl/hooks/tensorboard_hook.py
@@ -44,13 +44,8 @@ class ActivationStatisticsTensorboardWatcher(ActivationStatisticsObserver):
             global_step=stat.iteration,
         )
         self.writer.add_scalar(
-            tag="activations/" + stat.name + "/max",
-            scalar_value=stat.maxi,
-            global_step=stat.iteration,
-        )
-        self.writer.add_scalar(
-            tag="activations/" + stat.name + "/min",
-            scalar_value=stat.mini,
+            tag="activations/" + stat.name + "/spread",
+            scalar_value=stat.spread,
             global_step=stat.iteration,
         )
 
@@ -99,6 +94,7 @@ class SSLTensorboardHook(ClassyHook):
             self.activation_watcher = ActivationStatisticsMonitor(
                 observer=ActivationStatisticsTensorboardWatcher(tb_writer),
                 log_frequency=self.log_activation_statistics,
+                sample_feature_map=True,
             )
         logging.info(
             f"Tensorboard config: log_params: {self.log_params}, "

--- a/vissl/hooks/tensorboard_hook.py
+++ b/vissl/hooks/tensorboard_hook.py
@@ -116,7 +116,7 @@ class SSLTensorboardHook(ClassyHook):
         Called at the end of training.
         """
         if self.log_activation_statistics and is_primary():
-            self.activation_watcher.reset()
+            self.activation_watcher.stop()
 
     def on_forward(self, task: "tasks.ClassyTask") -> None:
         """

--- a/vissl/utils/activation_statistics.py
+++ b/vissl/utils/activation_statistics.py
@@ -91,7 +91,7 @@ class ActivationStatisticsMonitor:
                 h2 = m.register_forward_hook(self._create_post_forward_hook(name))
                 self._hooks.extend([h1, h2])
 
-    def reset(self):
+    def stop(self):
         """
         Stop any form of tracking (removes the hooks used to monitor the model)
         """

--- a/vissl/utils/activation_statistics.py
+++ b/vissl/utils/activation_statistics.py
@@ -108,8 +108,11 @@ class ActivationStatisticsMonitor:
 
     def _create_post_forward_hook(self, name: str):
         def _post_forward_hook(module: nn.Module, inputs, outputs):
+
             # Eliminate non-leaf modules as well as modules ignored by the forward
-            if self._prev_module_name != name:
+            previous_forward_module_name = self._prev_module_name
+            self._prev_module_name = None
+            if previous_forward_module_name != name:
                 return
 
             # Collect all outputs

--- a/vissl/utils/activation_statistics.py
+++ b/vissl/utils/activation_statistics.py
@@ -97,6 +97,7 @@ class ActivationStatisticsMonitor:
         """
         for h in self._hooks:
             h.remove()
+        self._hooks.clear()
         self.iteration = -1
         self._previous_module_name = None
 

--- a/vissl/utils/activation_statistics.py
+++ b/vissl/utils/activation_statistics.py
@@ -1,0 +1,146 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import abc
+from typing import NamedTuple, Set
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+class ActivationStatistics(NamedTuple):
+    """
+    Information collected on each activation:
+    - "name" of the module and "module_type"
+    - current "iteration" of training
+    - mean, min and max statistics
+    """
+
+    name: str
+    iteration: int
+    module_type: str
+    mean: float
+    maxi: float
+    mini: float
+
+
+class ActivationStatisticsObserver(abc.ABC):
+    """
+    Abstract interface to override to either collect or stream
+    statistics as they are produced
+    """
+
+    @abc.abstractmethod
+    def consume(self, stat: ActivationStatistics):
+        pass
+
+
+class ActivationStatisticsMonitor:
+    """
+    Watch via hooks the content of the model's activations during training
+    computes basic statistics on them, and stream them to an 'observer'.
+
+    This implementation only traces modules which:
+    - do not have child modules (ex: nn.Sequential modules are ignored)
+    - are in training mode (the goal is to identify divergences)
+
+    Depending on the 'observer' implementation, the results can be
+    accumulated or streamed to tensorboard (or any visualisation tool).
+    """
+
+    def __init__(
+        self,
+        observer: ActivationStatisticsObserver,
+        log_frequency: int,
+        ignored_modules: Set[str] = None,
+    ):
+        self.observer = observer
+        self.log_frequency = log_frequency
+        self.ignored_modules = ignored_modules
+        if self.ignored_modules is None:
+            self.ignored_modules = {"torch.nn.modules.activation.ReLU"}
+        self.iteration = -1
+        self._hooks = []
+        self._prev_module_name = None
+
+    def set_iteration(self, iteration: int):
+        self.iteration = iteration
+
+    def monitor(self, model: nn.Module):
+        for name, m in model.named_modules():
+            if self._get_qualified_type(m) not in self.ignored_modules:
+                h1 = m.register_forward_pre_hook(self._create_pre_forward_hook(name))
+                h2 = m.register_forward_hook(self._create_post_forward_hook(name))
+                self._hooks.extend([h1, h2])
+
+    def reset(self):
+        for h in self._hooks:
+            h.remove()
+        self.iteration = -1
+        self._prev_module_name = None
+
+    def _should_log(self, module: nn.Module):
+        return self.iteration % self.log_frequency == 0 and module.training
+
+    def _create_pre_forward_hook(self, name: str):
+        def _pre_forward_hook(module: nn.Module, inputs):
+            if self._should_log(module):
+                self._prev_module_name = name
+            else:
+                self._prev_module_name = None
+
+        return _pre_forward_hook
+
+    def _create_post_forward_hook(self, name: str):
+        def _post_forward_hook(module: nn.Module, inputs, outputs):
+            # Eliminate non-leaf modules as well as modules ignored by the forward
+            if self._prev_module_name != name:
+                return
+
+            outputs = self._collect_tensors(outputs, detach=True)
+            mean = np.mean([o.mean().item() for o in outputs])
+            maxi = np.max([o.max().item() for o in outputs])
+            mini = np.min([o.min().item() for o in outputs])
+            self.observer.consume(
+                ActivationStatistics(
+                    name=name,
+                    iteration=self.iteration,
+                    module_type=self._get_qualified_type(module),
+                    mean=mean,
+                    maxi=maxi,
+                    mini=mini,
+                )
+            )
+
+        return _post_forward_hook
+
+    @staticmethod
+    def _get_qualified_type(module: nn.Module):
+        return type(module).__module__ + "." + type(module).__name__
+
+    @staticmethod
+    def _collect_tensors(xs, detach=False):
+        tensors = []
+        to_visit = [xs]
+        while to_visit:
+            x = to_visit.pop()
+            if isinstance(x, torch.Tensor):
+                if detach:
+                    x = x.detach()
+                tensors.append(x)
+            elif isinstance(x, tuple) or isinstance(x, list):
+                to_visit.extend(xs)
+        return tensors
+
+
+class ActivationStatisticsAccumulator(ActivationStatisticsObserver):
+    """
+    Implementation of ActivationStatisticsObserver which collects
+    the statistics in a list (especially useful for tests)
+    """
+
+    def __init__(self):
+        self.stats = []
+
+    def consume(self, stat: ActivationStatistics):
+        self.stats.append(stat)

--- a/vissl/utils/tensorboard.py
+++ b/vissl/utils/tensorboard.py
@@ -70,4 +70,5 @@ def get_tensorboard_hook(cfg):
         log_params=cfg.HOOKS.TENSORBOARD_SETUP.LOG_PARAMS,
         log_params_every_n_iterations=cfg.HOOKS.TENSORBOARD_SETUP.LOG_PARAMS_EVERY_N_ITERS,
         log_params_gradients=cfg.HOOKS.TENSORBOARD_SETUP.LOG_PARAMS_GRADIENTS,
+        log_activation_statistics=cfg.MONITORING.MONITOR_ACTIVATION_STATISTICS,
     )


### PR DESCRIPTION
# Tracking activation statistics during training

This PR features a new monitoring utility, plugged in VISSL via the Tensorboard hook, which allows to capture the output of the "leaf modules" (not all modules) and compute mean and spread statistics on the output of each layer, and track them in tensorboard.

- [ ] @QuentinDuval to re-run performance tests after review comments and refactoring on SwAV
- [ ] @QuentinDuval to try to add some quick performance tests in the unit tests

## Output example:

<img width="689" alt="Screenshot 2021-04-07 at 08 52 10" src="https://user-images.githubusercontent.com/7412790/113869679-ff4f6980-977e-11eb-87c9-2d795ac7a019.png">

## Description

The configuration has been updated with the following option (by default disabled):

```
  MONITORING:
    # At which frequency do we monitor statistics on the activations:
    # - 0 means that we do not monitor statistics
    # - N > 0 means we monitor every N iterations
    MONITOR_ACTIVATION_STATISTICS: 0
```

Turn on the option with the following hydra override: `config.MONITORING.MONITOR_ACTIVATION_STATISTICS=50` to gather the statistics on all activations every 50 iterations.

**NOTE:** This option requires the tensorboard hook to be enabled to take effect.

**Performance impacts:** The collect of statistics makes use of the following optimisation: for feature maps, we only compute the statistics on the central feature, which requires less compute and memory than on the full feature map and still exercises all the weights of the BN or Conv2D layer. With this optimisation, the impact in terms of memory is negligible and the impact in terms of runtime is about 1.4% on SimCLR, when the frequency of collection is every 50 iterations.

## Further improvements

- Support for other backend than just Tensorboard: ideally, we should be able to dump raw data / images
- Profile what takes time when computing statistics and optimise it further if possible
- Adding an "alerting" feature which varies the speed of tracking based on detected divergence