### PR TITLE
[benchmark] (SUN397) Add SUN397 dataset and associated benchmarks

### DIFF
--- a/configs/config/benchmark/linear_image_classification/sun397/eval_resnet_8gpu_transfer_sun397_linear.yaml
+++ b/configs/config/benchmark/linear_image_classification/sun397/eval_resnet_8gpu_transfer_sun397_linear.yaml
@@ -1,0 +1,112 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 200
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  HOOKS:
+    PERF_STATS:
+      MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [disk_filelist]
+      LABEL_SOURCES: [disk_filelist]
+      DATASET_NAMES: [sun397_filelist]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: [224, 224]
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/sun397/
+    TEST:
+      DATA_SOURCES: [disk_filelist]
+      LABEL_SOURCES: [disk_filelist]
+      DATASET_NAMES: [sun397_filelist]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: [224, 224]
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/sun397/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1, 5]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_ONLY: True
+      SHOULD_FLATTEN_FEATS: False
+      LINEAR_EVAL_FEAT_POOL_OPS_MAP: [
+        ["res5", ["AdaptiveAvgPool2d", [[1, 1]]]],
+      ]
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["eval_mlp", {"in_channels": 2048, "dims": [2048, 397]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+      # STATE_DICT_KEY_NAME: model_state_dict
+    SYNC_BN_CONFIG:
+      CONVERT_BN_TO_SYNC_BN: True
+      SYNC_BN_TYPE: apex
+      GROUP_SIZE: 8
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+      name: sgd
+      # In the OSS Caffe2 benchmark, RN50 models use 1e-4 and AlexNet models 5e-4
+      weight_decay: 0.0005
+      momentum: 0.9
+      num_epochs: 28
+      nesterov: True
+      regularize_bn: False
+      regularize_bias: True
+      param_schedulers:
+        lr:
+          auto_lr_scaling:
+            auto_scale: true
+            base_value: 0.01
+            base_lr_batch_size: 256
+          name: multistep
+          values: [0.01, 0.001, 0.0001, 0.00001]
+          milestones: [8, 16, 24]
+          update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/benchmark/low_shot_transfer/sun397/eval_resnet_8gpu_transfer_sun397_low_tune.yaml
+++ b/configs/config/benchmark/low_shot_transfer/sun397/eval_resnet_8gpu_transfer_sun397_low_tune.yaml
@@ -1,0 +1,106 @@
+# @package _global_
+config:
+  VERBOSE: True
+  LOG_FREQUENCY: 100
+  TEST_ONLY: False
+  TEST_EVERY_NUM_EPOCH: 1
+  TEST_MODEL: True
+  SEED_VALUE: 1
+  MULTI_PROCESSING_METHOD: forkserver
+  HOOKS:
+    PERF_STATS:
+      MONITOR_PERF_STATS: True
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [disk_filelist]
+      LABEL_SOURCES: [disk_filelist]
+      DATASET_NAMES: [sun397_filelist]
+      DATA_LIMIT: 1000
+      DATA_LIMIT_SAMPLING:
+        IS_BALANCED: True
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: [224, 224]
+        - name: RandomHorizontalFlip
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/sun397/
+    TEST:
+      DATA_SOURCES: [disk_filelist]
+      LABEL_SOURCES: [disk_filelist]
+      DATASET_NAMES: [sun397_filelist]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: [224, 224]
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: True
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/sun397/
+  METERS:
+    name: accuracy_list_meter
+    accuracy_list_meter:
+      num_meters: 1
+      topk_values: [1, 5]
+  TRAINER:
+    TRAIN_STEP_NAME: standard_train_step
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      EVAL_TRUNK_AND_HEAD: False
+    TRUNK:
+      NAME: resnet
+      TRUNK_PARAMS:
+        RESNETS:
+          DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [2048, 397]}],
+      ]
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+      APPEND_PREFIX: trunk.
+  LOSS:
+    name: cross_entropy_multiple_output_single_target
+    cross_entropy_multiple_output_single_target:
+      ignore_index: -1
+  OPTIMIZER:
+    name: sgd
+    weight_decay: 0.0005
+    momentum: 0.9
+    num_epochs: 90
+    nesterov: True
+    regularize_bn: False
+    regularize_bias: True
+    param_schedulers:
+      lr:
+        auto_lr_scaling:
+          auto_scale: true
+          base_value: 0.1
+          base_lr_batch_size: 256
+        values: [0.1, 0.01, 0.001]
+        milestones: [30, 60]
+        name: multistep
+        update_interval: epoch
+  DISTRIBUTED:
+    BACKEND: nccl
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 8
+    INIT_METHOD: tcp
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "."
+    AUTO_RESUME: True
+    CHECKPOINT_FREQUENCY: 1

--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -95,6 +95,10 @@
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]
     },
+    "sun397_filelist": {
+        "train": ["<path_to_train_images.npy>", "<path_to_train_labels.npy>"],
+        "val": ["<path_to_val_images.npy>", "<path_to_val_labels.npy>"]
+    },
     "ucf101_folder": {
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]

--- a/docs/source/evaluations/linear_benchmark.rst
+++ b/docs/source/evaluations/linear_benchmark.rst
@@ -248,6 +248,21 @@ is provided `here <https://github.com/facebookresearch/vissl/tree/master/configs
 A script to automatically prepare the data for FOOD-101 is available `here <https://github.com/facebookresearch/vissl/tree/master/extra_scripts>`_.
 
 
+Benchmark: SUN397
+-----------------------
+
+The configuration setting for this benchmark
+is provided `here <https://github.com/facebookresearch/vissl/tree/master/configs/config/benchmark/linear_image_classification/sun397>`_ .
+
+.. code-block:: bash
+
+    python tools/run_distributed_engines.py \
+      config=benchmark/linear_image_classification/sun397/eval_resnet_8gpu_transfer_sun397_linear \
+      config.MODEL.WEIGHTS_INIT.PARAMS_FILE=<my_weights.torch>
+
+A script to automatically prepare the data for SUN397 is available `here <https://github.com/facebookresearch/vissl/tree/master/extra_scripts>`_.
+
+
 Benchmark: UCF-101
 -----------------------
 

--- a/docs/source/evaluations/low_shot_transfer.rst
+++ b/docs/source/evaluations/low_shot_transfer.rst
@@ -159,6 +159,20 @@ For fine-tuning on the full dataset, just add this option to the command line :c
 Scripts to automatically prepare the data for the Small NORB benchmarks are available `here <https://github.com/facebookresearch/vissl/tree/master/extra_scripts>`_.
 
 
+Benchmark: SUN397
+-----------------------
+
+The configuration for low shot (1000 samples) fine-tuning on SUN397 is provided `here <https://github.com/facebookresearch/vissl/tree/master/configs/config/benchmark/low_shot_transfer/sun397>`_ .
+
+.. code-block:: bash
+
+    python tools/run_distributed_engines.py \
+      config=benchmark/low_shot_transfer/sun397/eval_resnet_8gpu_transfer_sun397_low_tune \
+      config.MODEL.WEIGHTS_INIT.PARAMS_FILE=<my_weights.torch>
+
+For fine-tuning on the full dataset, just add this option to the command line :code:`config.DATA.TRAIN.DATA_LIMIT=-1`.
+
+
 Benchmark: SVHN
 -----------------------
 

--- a/docs/source/vissl_modules/data.rst
+++ b/docs/source/vissl_modules/data.rst
@@ -258,6 +258,7 @@ To run these benchmarks, the following data preparation scripts are mandatory:
 - :code:`create_patch_camelyon_data_files.py`: to transform the `PatchCamelyon <https://github.com/basveeling/pcam>`_ dataset to the :code:`disk_folder` format
 - :code:`create_small_norb_azimuth_data_files.py` to create a :code:`disk_folder` dataset from `Small NORB <https://cs.nyu.edu/~ylclab/data/norb-v1.0-small/>`_ where the goal is to find the azimuth or the photographed object
 - :code:`create_small_norb_elevation_data_files.py` to create a :code:`disk_folder` dataset from `Small NORB <https://cs.nyu.edu/~ylclab/data/norb-v1.0-small/>`_ where the goal is to predict the elevation in the image
+- :code:`create_sun397_data_files.py` to transform the `SUN397 <https://vision.princeton.edu/projects/2010/SUN/>`_ dataset to the :code:`disk_filelist` format
 - :code:`create_ucf101_data_files.py`: to create a :code:`disk_folder` image action recognition dataset from the video action recognition dataset `UCF101 <https://www.crcv.ucf.edu/data/UCF101.php>`_ by extracting the middle frame
 
 You can read more about how to download these datasets and run these scripts from `here <https://github.com/facebookresearch/vissl/blob/master/extra_scripts/README.md>`_.

--- a/extra_scripts/README.md
+++ b/extra_scripts/README.md
@@ -21,6 +21,7 @@ To run these benchmarks, the following data preparation scripts are mandatory:
 - `create_patch_camelyon_data_files.py`: to transform the [PatchCamelyon](https://github.com/basveeling/pcam) dataset to the `disk_folder` format
 - `create_small_norb_azimuth_data_files.py` to create a `disk_folder` dataset from [Small NORB](https://cs.nyu.edu/~ylclab/data/norb-v1.0-small/) where the goal is to find the azimuth or the photographed object
 - `create_small_norb_elevation_data_files.py` to create a `disk_folder` dataset from [Small NORB](https://cs.nyu.edu/~ylclab/data/norb-v1.0-small/) where the goal is to predict the elevation in the image
+- `create_sun397_data_files.py` to transform the [SUN397](https://vision.princeton.edu/projects/2010/SUN/) dataset to the `disk_filelist` format
 - `create_ucf101_data_files.py`: to create a `disk_folder` image action recognition dataset from the video action recognition dataset [UCF101](https://www.crcv.ucf.edu/data/UCF101.php) by extracting the middle frame
 
 ### Unified data preparation interface
@@ -385,6 +386,28 @@ The last step is to set this path in `dataset_catalog.json` and you are good to 
     "val": ["/output_path/to/cars/val", "<ignored>"]
 },
 ```
+
+### Preparing the SUN397 data files
+
+Run the `create_sun397_data_files.py` script with the `-d` option as follows:
+
+```bash
+python extra_scripts/create_sun397_data_files.py \
+    -i /path/to/sun397/ \
+    -o /path/to/sun397/ \
+    -d
+```
+
+The folder `/path/to/sun397/` now contains the Stanford Cars `disk_filelist` dataset.
+The last step is to set this path in `dataset_catalog.json` and you are good to go:
+
+```
+"sun397_filelist": {
+    "train": ["/checkpoint/qduval/datasets/sun397/train_images.npy", "/checkpoint/qduval/datasets/sun397/train_labels.npy"],
+    "val": ["/checkpoint/qduval/datasets/sun397/val_images.npy", "/checkpoint/qduval/datasets/sun397/val_labels.npy"]
+},
+```
+
 
 ### Preparing UCF101/image data files
 

--- a/extra_scripts/create_sun397_data_files.py
+++ b/extra_scripts/create_sun397_data_files.py
@@ -1,0 +1,146 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+import argparse
+import dataclasses
+import os
+import random
+from typing import List
+
+import numpy as np
+from torchvision.datasets.utils import download_and_extract_archive
+from tqdm import tqdm
+
+
+def get_argument_parser():
+    """
+    List of arguments supported by the script
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        help="Path to the folder containing the original SUN397 folder",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Folder where the classification dataset will be written",
+    )
+    parser.add_argument(
+        "-d",
+        "--download",
+        action="store_const",
+        const=True,
+        default=False,
+        help="To download the original dataset and decompress it in the input folder",
+    )
+    parser.add_argument(
+        "-s",
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used to create the train/val/test splits",
+    )
+    return parser
+
+
+def download_dataset(root: str):
+    """
+    Download the SUN397 dataset archive and expand it in the folder provided as parameter
+    """
+    URL = "http://vision.princeton.edu/projects/2010/SUN/SUN397.tar.gz"
+    download_and_extract_archive(url=URL, download_root=root)
+
+
+TRAIN_SPLIT_SIZE = 0.7
+VALID_SPLIT_SIZE = 0.1
+
+
+@dataclasses.dataclass
+class SplitData:
+    """
+    Data structure holding the samples associated to a given split
+    """
+
+    image_paths: List[str] = dataclasses.field(default_factory=list)
+    image_labels: List[int] = dataclasses.field(default_factory=list)
+
+
+def split_sample_list(xs):
+    """
+    Split a list of samples in train/val/test splits
+    """
+    random.shuffle(xs)
+    n = len(xs)
+    val_start = int(round(n * TRAIN_SPLIT_SIZE))
+    val_length = int(round(n * VALID_SPLIT_SIZE))
+    val_end = val_start + val_length
+    return {
+        "train": xs[:val_start],
+        "val": xs[val_start:val_end],
+        "test": xs[val_end:],
+        "trainval": xs[:val_end],
+    }
+
+
+def create_sun397_disk_filelist_dataset(input_path: str, output_path: str, seed: int):
+    """
+    Create partitions "train", "trainval", "val", "test" from the input path of SUN397
+    by allocating 70% of labels to "train", 10% to "val" and 20% to "test".
+    """
+    random.seed(seed)
+    os.makedirs(output_path, exist_ok=True)
+
+    # List all the available classes in SUN397 and their path
+    image_folder = os.path.join(input_path, "SUN397")
+    class_names_file = os.path.join(image_folder, "ClassName.txt")
+    class_paths = []
+    with open(class_names_file, "r") as f:
+        for line in f:
+            path = line.strip()
+            if path.startswith("/"):
+                path = path[1:]
+            class_paths.append(path)
+
+    # For each label, split the samples in train/val/test and add them
+    # to the list of samples associated to each split
+    splits_data = {
+        "train": SplitData(),
+        "val": SplitData(),
+        "test": SplitData(),
+        "trainval": SplitData(),
+    }
+    for i, class_path in tqdm(enumerate(class_paths), total=len(class_paths)):
+        full_class_path = os.path.join(image_folder, class_path)
+        image_names = os.listdir(full_class_path)
+        splits = split_sample_list(image_names)
+        for split, images in splits.items():
+            for image_name in images:
+                image_path = os.path.join(full_class_path, image_name)
+                splits_data[split].image_paths.append(image_path)
+                splits_data[split].image_labels.append(i)
+
+    # Save each split
+    for split, samples in splits_data.items():
+        image_output_path = os.path.join(output_path, f"{split}_images.npy")
+        label_output_path = os.path.join(output_path, f"{split}_labels.npy")
+        np.save(image_output_path, np.array(samples.image_paths))
+        np.save(label_output_path, np.array(samples.image_labels))
+
+
+if __name__ == "__main__":
+    """
+    Example usage:
+
+    ```
+    python extra_scripts/create_sun397_data_files.py -i /path/to/sun397/ -o /output_path/to/sun397 -d
+    ```
+    """
+    args = get_argument_parser().parse_args()
+    if args.download:
+        download_dataset(args.input)
+    create_sun397_disk_filelist_dataset(
+        input_path=args.input, output_path=args.output, seed=args.seed
+    )


### PR DESCRIPTION
This PR adds the SUN397 dataset using in VTAB, with automatic download supported, with the splits created similarly to what is being done in VTAB, and includes the configuration and documentation for the associated benchmark:
- one for linear evaluation on the full dataset (around 87000 images)
- one for VTAB-like low shot transfer on 1000 images (challenging benchmark since there are 397 classes)

I tested the performance on SimCLR and the results are in line with was is reported in the SimCLR paper.

One more step in the direction of VTAB / CLIP like benchmark suites :)
