### PR TITLE
[Proposal] TensorBoard fixes to discuss

### DIFF
--- a/vissl/hooks/__init__.py
+++ b/vissl/hooks/__init__.py
@@ -114,7 +114,9 @@ def default_hook_generator(cfg: AttrDict) -> List[ClassyHook]:
             "`conda install -c conda-forge tensorboard`"
         )
         tb_hook = get_tensorboard_hook(cfg)
-        hooks.extend([tb_hook])
+        if tb_hook is not None:
+            hooks.append(tb_hook)
+
     if cfg.MODEL.GRAD_CLIP.USE_GRAD_CLIP:
         hooks.extend(
             [

--- a/vissl/utils/distributed_launcher.py
+++ b/vissl/utils/distributed_launcher.py
@@ -212,8 +212,11 @@ class _ResumableSlurmJob:
         node_id = environment.global_rank
         master_ip = environment.hostnames[0]
         master_port = self.config.SLURM.PORT_ID
+        job_id = environment.job_id
+
         self.config.DISTRIBUTED.INIT_METHOD = "tcp"
         self.config.DISTRIBUTED.RUN_ID = f"{master_ip}:{master_port}"
+        self.config.HOOKS.TENSORBOARD_SETUP.EXPERIMENT_LOG_DIR += "/" + job_id
         launch_distributed(
             cfg=self.config,
             node_id=node_id,

--- a/vissl/utils/tensorboard.py
+++ b/vissl/utils/tensorboard.py
@@ -5,8 +5,8 @@ This script contains some helpful functions to handle tensorboard setup.
 """
 
 import logging
+import os
 
-from vissl.utils.checkpoint import get_checkpoint_folder
 from vissl.utils.io import makedir
 
 
@@ -29,20 +29,24 @@ def is_tensorboard_available():
     return tb_available
 
 
-def get_tensorboard_dir(cfg):
+def get_tensorboard_dir(config):
     """
     Get the output directory where the tensorboard events will be written.
 
     Args:
-        cfg (AttrDict): User specified config file containing the settings for the
+        config (AttrDict): User specified config file containing the settings for the
                         tensorboard as well like log directory, logging frequency etc
 
     Returns:
         tensorboard_dir (str): output directory path
 
     """
-    checkpoint_folder = get_checkpoint_folder(cfg)
-    tensorboard_dir = f"{checkpoint_folder}/tb_logs"
+    tensorboard_dir = os.path.join(
+        config.HOOKS.TENSORBOARD_SETUP.LOG_DIR,
+        config.HOOKS.TENSORBOARD_SETUP.EXPERIMENT_LOG_DIR
+    )
+    if config.DISTRIBUTED.NUM_NODES > 1 and config.CHECKPOINT.APPEND_DISTR_RUN_ID:
+        tensorboard_dir = f"{tensorboard_dir}/{config.DISTRIBUTED.RUN_ID}"
     logging.info(f"Tensorboard dir: {tensorboard_dir}")
     makedir(tensorboard_dir)
     return tensorboard_dir


### PR DESCRIPTION
This PR is a follow up on a few issues that were discussed in https://github.com/facebookresearch/vissl/pull/264 regarding TensorBoard:
1. The current implementation creates several `SummaryWriter` although they will not be used (only the primary process logs for the time being) leading to empty files
2. The current implementation uses the checkpoint directory instead of the configuration dedicated to tensorboard for logging

Now, things are not so simple regarding point 2: to distinguish two jobs running on the same configuration, I concatenated the JOB_ID of SLURM, which is unique (allows to distinguish jobs), stable (upon pre-emption it stays the same) and useful to find back which job produced what log.

But I do not know if there is such a trick for other job schedulers: the advantage of using the checkpoint directory was that it was unique to a JOB and stable, allowing TB to know in which file to log even after pre-emption. So I am a bit unsure about the consequences of the second point.