### PR TITLE
add requirements.txt to MANIFEST, in support of making pip package by…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ global-exclude *.pyc
 global-exclude __pycache__
 recursive-include configs/ *.yaml
 include vissl/config/defaults.yaml
+include requirements.txt


### PR DESCRIPTION
add requirements.txt to MANIFEST, in support of making pip package by 'python setup.py sdist', so it's easy to install by 'pip install vissl-0.1.5.tar.gz'