### PR TITLE
Add NUM_CPU_PER_PROC and ADDITIONAL_PARAMETERS to slurm hydra config

### DIFF
--- a/docs/source/train_resource_setup.rst
+++ b/docs/source/train_resource_setup.rst
@@ -67,6 +67,12 @@ While the more SLURM specific options are located in the "SLURM" configuration b
     MEM_GB: 250
     # TCP port on which the workers will synchronize themselves with torch distributed
     PORT_ID: 40050
+    # Number of CPUs per GPUs to request on the cluster.
+    NUM_CPU_PER_PROC: 8
+    # Any other parameters for slurm (e.g. account, hint, distribution, etc.,)
+    # Please see https://github.com/facebookincubator/submitit/issues/23#issuecomment-695217824.
+    ADDITIONAL_PARAMETERS: {}
+
 
 Users can customize these values by using the standard hydra override syntax (same as for any other item in the configuration), or can modify the script to fit their needs.
 

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -1002,7 +1002,7 @@ config:
     # number of machines to use in training. Each machine can have many gpus. NODES count
     # number of unique hosts.
     NUM_NODES: 1
-    # set this to the number of gpus per machine. This ensrures that each gpu of the
+    # set this to the number of gpus per machine. This ensures that each gpu of the
     # node has a process attached to it.
     NUM_PROC_PER_NODE: 8
     # this could be: tcp | env | file or any other pytorch supported methods
@@ -1042,6 +1042,11 @@ config:
     MEM_GB: 250
     # TCP port on which the workers will synchronize themselves with torch distributed
     PORT_ID: 40050
+    # Number of CPUs per GPUs to request on the cluster.
+    NUM_CPU_PER_PROC: 8
+    # Any other parameters for slurm (e.g. account, hint, distribution, etc.,) as dictated by submitit.
+    # Please see https://github.com/facebookincubator/submitit/issues/23#issuecomment-695217824.
+    ADDITIONAL_PARAMETERS: {}
 
   # ----------------------------------------------------------------------------------- #
   # SVM (benchmark)

--- a/vissl/utils/distributed_launcher.py
+++ b/vissl/utils/distributed_launcher.py
@@ -256,10 +256,11 @@ def launch_distributed_on_slurm(cfg: AttrDict, engine_name: str):
         slurm_constraint=cfg.SLURM.CONSTRAINT,
         timeout_min=cfg.SLURM.TIME_HOURS * 60,
         nodes=cfg.DISTRIBUTED.NUM_NODES,
-        cpus_per_task=8 * cfg.DISTRIBUTED.NUM_PROC_PER_NODE,
+        cpus_per_task=cfg.SLURM.NUM_CPU_PER_PROC * cfg.DISTRIBUTED.NUM_PROC_PER_NODE,
         tasks_per_node=1,
         gpus_per_node=cfg.DISTRIBUTED.NUM_PROC_PER_NODE,
         mem_gb=cfg.SLURM.MEM_GB,
+        slurm_additional_parameters=cfg.SLURM.ADDITIONAL_PARAMETERS,
     )
     trainer = _ResumableSlurmJob(engine_name=engine_name, config=cfg)
     job = executor.submit(trainer)


### PR DESCRIPTION
**Description**

Add NUM_CPU_PER_PROC and ADDITIONAL_PARAMETERS to slurm hydra config. This will allow users to configure critical slurm options.

**Test Plan:** 

1.

```
./dev/launch_slurm.sh config=test/integration_test/quick_simclr \
config.DATA.TRAIN.DATA_SOURCES='[synthetic]'  \
config.SLURM.CPU_PER_PROC=10 
```
Correctly configures the the CPU_PER_PROC in the slurm cluster.

2.

Adding: 
```
    SLURM:
        ADDITIONAL_PARAMETERS:
            account: test
```
to config test/integration_test/quick_simclr.yaml.  And running:

```
./dev/launch_slurm.sh config=test/integration_test/quick_simclr config.DATA.TRAIN.DATA_SOURCES='[synthetic]' 
```
correctly configures the SLURM account upon submitting. 

