### PR TITLE
[WIP]Add ability to set dataset catalog for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ website/pages/tutorials/*
 *-checkpoint.ipynb
 **/.ipynb_checkpoints
 **/.ipynb_checkpoints/**
+
+# Configs for local development
+configs/config_local/*


### PR DESCRIPTION
Summary:
Add ability to set dataset catalog for local development.

This will allow you to have a gitignored local_config where you can house a second dataset_catalog, that you can alter for development purposes.

I would also recommend copying the config folder into your gitignored local_config folder, so that you can also change the YAML files freely without having to worry about source control.

Differential Revision: D27652513

