### PR TITLE
Small fix to the optimizer param groups for the bias parameter

### DIFF
--- a/vissl/optimizers/optimizer_helper.py
+++ b/vissl/optimizers/optimizer_helper.py
@@ -182,7 +182,7 @@ def get_optimizer_param_groups(
                 if optimizer_config["regularize_bias"]:
                     trunk_regularized_params.append(module.bias)
                 else:
-                    trunk_regularized_params.append(module.bias)
+                    trunk_unregularized_params.append(module.bias)
         # trunk, BN layer
         elif isinstance(module, _BN_TYPES):
             (


### PR DESCRIPTION
if we don't want to regularize the bias, we should add it to the unregularized params list. fixing this

@mathildecaron31 caught this. thanks to her for spotting the issue.