### PR TITLE
Small fix to the integration test with disk data deprecation

### DIFF
--- a/configs/config/test/integration_test/quick_pirl.yaml
+++ b/configs/config/test/integration_test/quick_pirl.yaml
@@ -16,8 +16,8 @@ config:
   DATA:
     NUM_DATALOADER_WORKERS: 5
     TRAIN:
-      DATA_SOURCES: [disk_folder]
-      DATASET_NAMES: [imagenet1k_folder]
+      DATA_SOURCES: [disk_filelist]
+      DATASET_NAMES: [imagenet1k_filelist]
       BATCHSIZE_PER_REPLICA: 32
       LABEL_TYPE: sample_index
       TRANSFORMS:

--- a/configs/config/test/integration_test/quick_simclr_regnet.yaml
+++ b/configs/config/test/integration_test/quick_simclr_regnet.yaml
@@ -15,8 +15,8 @@ config:
   DATA:
     NUM_DATALOADER_WORKERS: 5
     TRAIN:
-      DATA_SOURCES: [disk_folder]
-      DATASET_NAMES: [imagenet1k_folder]
+      DATA_SOURCES: [disk_filelist]
+      DATASET_NAMES: [imagenet1k_filelist]
       BATCHSIZE_PER_REPLICA: 32
       LABEL_TYPE: sample_index    # just an implementation detail. Label isn't used
       TRANSFORMS:

--- a/vissl/hooks/state_update_hooks.py
+++ b/vissl/hooks/state_update_hooks.py
@@ -281,7 +281,8 @@ class FreezeParametersHook(ClassyHook):
                 matched_named_params += 1
                 p.grad = None
         # TODO (Min): we need to check the exact target number.
-        assert matched_named_params > 0, (
-            f"Didn't find expected number of layers: "
-            f"{matched_named_params} vs.  {len(map_params_to_iters)}"
-        )
+        if task.iteration >= max_iterations:
+            assert matched_named_params > 0, (
+                f"Didn't find expected number of layers: "
+                f"{matched_named_params} vs.  {len(map_params_to_iters)}"
+            )


### PR DESCRIPTION
Summary: Updating the integration tests as the local datasets on cluster machines are now deprecated. Updating the integration tests to run without the disk folder datasets and instead use the disk_filelist  which enables manifold datasets (the data paths are manifold in the disk_filelist in fbcode)

Differential Revision: D27724042

