### PR TITLE
supports training with airstore datasets

### DIFF
--- a/configs/config/dataset_catalog.json
+++ b/configs/config/dataset_catalog.json
@@ -1,4 +1,8 @@
 {
+    "airstore_imagenet": {
+        "train": ["airstore://flashblade_imagenet_train", "<unused>"],
+        "val": ["airstore://flashblade_imagenet_val", "<unused>"]
+    },
     "imagenet1k_folder": {
         "train": ["<img_path>", "<lbl_path>"],
         "val": ["<img_path>", "<lbl_path>"]

--- a/dev/launch_slurm.sh
+++ b/dev/launch_slurm.sh
@@ -25,7 +25,7 @@ CFG=( "$@" )
 # create a temporary experiment folder to run the SLURM job in isolation
 RUN_ID=$(date +'%Y-%m-%d-%H-%M-%S')
 EXP_ROOT_DIR="/checkpoint/$USER/vissl/$RUN_ID"
-CHECKPOINT_DIR="$EXP_ROOT_DIR/checkpoints/"
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-"$EXP_ROOT_DIR/checkpoints/"}
 
 echo "EXP_ROOT_DIR: $EXP_ROOT_DIR"
 echo "CHECKPOINT_DIR: $CHECKPOINT_DIR"

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -27,6 +27,7 @@ from vissl.utils.misc import setup_multiprocessing_method
 
 
 __all__ = [
+    "AirstoreDataset",
     "GenericSSLDataset",
     "get_data_files",
     "register_datasets",

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 from classy_vision.dataset import DataloaderAsyncGPUWrapper
 from torch.utils.data import DataLoader
+from vissl.data.airstore_dataset import AirstoreDataset
 from vissl.data.collators import get_collator
 from vissl.data.data_helper import (
     DeterministicDistributedSampler,
@@ -18,7 +19,6 @@ from vissl.data.dataset_catalog import (
     get_data_files,
     register_datasets,
 )
-from vissl.data.airstore_dataset import AirstoreDataset
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -18,6 +18,7 @@ from vissl.data.dataset_catalog import (
     get_data_files,
     register_datasets,
 )
+from vissl.data.airstore_dataset import AirstoreDataset
 from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset
@@ -33,6 +34,7 @@ __all__ = [
 ]
 
 DATASET_SOURCE_MAP = {
+    "airstore": AirstoreDataset,
     "disk_filelist": DiskImageDataset,
     "disk_folder": DiskImageDataset,
     "torchvision_dataset": TorchvisionDataset,

--- a/vissl/data/airstore_dataset.py
+++ b/vissl/data/airstore_dataset.py
@@ -1,0 +1,130 @@
+
+import io
+import logging
+import torch
+
+
+from classy_vision.generic.distributed_util import get_rank, get_world_size
+from iopath.common.file_io import PathManager
+from PIL import Image, ImageFile
+from vissl.data.data_helper import QueueDataset, get_mean_image
+
+
+def create_path_manager():
+    # inline import until we have an AIRStore OSS public package
+    from airstore.client.airstore_tabular import AIRStorePathHandler
+    pathmgr = PathManager()
+    pathmgr.register_handler(AIRStorePathHandler())
+    pathmgr.set_strict_kwargs_checking(False)
+    return pathmgr
+
+
+class AirstoreDataset(QueueDataset):
+    def __init__(self, cfg, data_source, path, split, dataset_name):
+        super(AirstoreDataset, self).__init__(
+            queue_size=cfg["DATA"][split]["BATCHSIZE_PER_REPLICA"]
+        )
+        self.pathmgr = create_path_manager()
+        self.cfg = cfg
+        self.batch_size = cfg["DATA"][split]["BATCHSIZE_PER_REPLICA"]
+        self.airstore_uri = path
+        self.split = split
+        self.epoch = 0
+        self.start_iter = 0
+        self.enable_queue_dataset = cfg["DATA"][self.split]["ENABLE_QUEUE_DATASET"]
+        self.global_rank = get_rank()
+        self.global_world_size = get_world_size()
+        self._iterator = None
+
+
+    def set_epoch(self, epoch):
+        # set by trainer when train on new epoch or restore from a checkpoint
+        logging.info(f"set epoch to {epoch} in airstore dataset")
+        self.epoch = epoch;
+
+    def set_start_iter(self, start_iter):
+        # set by trainer when train on restoring from a checkpoint
+        self.start_iter = start_iter
+
+    def _open_iterator(self):
+        # data iterator from airstore for current data split.
+        # data are sharded by global total number of workers after shuffling
+        
+        data_cfg = self.cfg["DATA"]
+        split_cfg = data_cfg[self.split]
+
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            num_workers = 1
+            worker_id = 0
+        else:
+            num_workers = worker_info.num_workers;
+            worker_id = worker_info.id
+
+        return self.pathmgr.opent(
+            self.airstore_uri,
+            "r",
+            skip_samples=self.start_iter * self.batch_size,
+            enable_shuffle=getattr(split_cfg, "AIRSTORE_ENABLE_SHUFFLE", True),
+            shuffle_window=getattr(split_cfg, "AIRSTORE_SHUFFLE_WINDOW", 128),
+            seed=self.epoch,
+            world_size=self.global_world_size * num_workers, # split the dataset for each worker
+            rank=self.global_rank * num_workers + worker_id, # each worker take it's split by it's parent process rank and worker id
+            limit=getattr(split_cfg, "DATA_LIMIT", -1),
+            offset=getattr(split_cfg, "DATA_OFFSET", 0),
+            num_of_threads=getattr(split_cfg, "AIRSTORE_NUM_OF_THREADS", 2),
+            prefetch=getattr(split_cfg, "AIRSTORE_PREFETCH", 1),
+            max_holding_bundles=getattr(split_cfg, "AIRSTORE_MAX_HOLDING_BUNDLES", 5),
+            bundle_download_timeout_ms=getattr(split_cfg, "AIRSTORE_BUNDLE_DOWNLOAD_TIMEOUT_MS", 30000),
+            max_retries=getattr(split_cfg, "AIRSTORE_MAX_RETRIES", 5),
+            dataset_catalog_path=getattr(split_cfg, "AIRSTORE_DS_CATALOG_PATH", None), # temporary need during airstore development
+            env="OSS",
+        )
+
+
+    def num_samples(self):
+        return self._open_iterator().total_size
+
+
+    def __len__(self):
+        return self.num_samples();
+
+    def __getitem__(self, index):
+        if self._iterator is None:
+            self._iterator = self._open_iterator()
+
+        if not self.queue_init and self.enable_queue_dataset:
+            self._init_queues()
+
+        try:
+            # TODO (wpc, prigoyal): we should check images are good when we are
+            # uploading them to airstore.
+            ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+            image_bytes = next(self._iterator)["image"]
+            img = Image.open(io.BytesIO(image_bytes))
+
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+                
+            if self.enable_queue_dataset:
+                self.on_sucess(img)
+            is_success = True
+        except Exception as e:
+            # TODO: airstore should have no failed images
+            #       because they are filtered at prepare time.
+            #       Then, this should be removed.
+            logging.warning(e)
+            is_success = False
+            # if we have queue dataset class enabled, we try to use it to get
+            # the seen valid images
+            if self.enable_queue_dataset:
+                img, is_success = self.on_failure()
+                if img is None:
+                    raise RuntimeError(
+                        "Encountered invalid image and couldn't load from QueueDataset"
+                    )
+            else:
+                img = get_mean_image(self.cfg["DATA"][self.split].DEFAULT_GRAY_IMG_SIZE)
+        return img, is_success
+

--- a/vissl/data/airstore_dataset.py
+++ b/vissl/data/airstore_dataset.py
@@ -52,6 +52,9 @@ class AirstoreDataset(QueueDataset):
 
     def set_start_iter(self, start_iter: int):
         # set by trainer when train on restoring from a checkpoint
+        logging.info(f"set start_iter to {start_iter} in airstore dataset")
+        if start_iter < 0:
+            raise Exception(f"{start_iter} is not a valid iteration value")
         self.start_iter = start_iter
 
     def _open_iterator(self) -> Iterable[Any]:

--- a/vissl/data/airstore_dataset.py
+++ b/vissl/data/airstore_dataset.py
@@ -58,9 +58,13 @@ class AirstoreDataset(QueueDataset):
         self.start_iter = start_iter
 
     def _calculate_skip_samples(self, num_workers: int, worker_id: int) -> int:
+        # this function is used for calcuate how many samples we should skip per
+        # each worker when resuming from a checkpoint
         per_replica_skip = self.start_iter * self.batch_size
         per_worker_skip = per_replica_skip // num_workers
-        # dataloader round robin base on worker id when fetching data
+        # since dataloader fetching from each worker by roundrobin so we can
+        # calculate exactly which worker has one extra to skip when per_replica_skip
+        # can't be divided by num_workers cleanly
         if worker_id < per_replica_skip % num_workers:
             per_worker_skip += 1
         return per_worker_skip

--- a/vissl/data/airstore_dataset.py
+++ b/vissl/data/airstore_dataset.py
@@ -2,16 +2,16 @@
 
 import io
 import logging
-
-import torch
-from classy_vision.generic.distributed_util import get_rank, get_world_size
-from iopath.common.file_io import PathManager
-from PIL import Image, ImageFile
 from typing import (
     Any,
     Iterable,
     Tuple,
 )
+
+import torch
+from classy_vision.generic.distributed_util import get_rank, get_world_size
+from iopath.common.file_io import PathManager
+from PIL import Image, ImageFile
 from vissl.config import AttrDict
 from vissl.data.data_helper import QueueDataset, get_mean_image
 
@@ -111,10 +111,10 @@ class AirstoreDataset(QueueDataset):
             max_retries=getattr(split_cfg, "AIRSTORE_MAX_RETRIES", 5),
             dataset_catalog_path=getattr(
                 split_cfg, "AIRSTORE_DS_CATALOG_PATH", None
-            ), # temporary need during airstore development
+            ),  # temporary need during airstore development
             env=getattr(
                 split_cfg, "AIRSTORE_ENV", "OSS"
-            ), # env need set to "fb" if run in FB, otherwise set to "OSS"
+            ),  # env need set to "fb" if run in FB, otherwise set to "OSS"
         )
 
     def num_samples(self) -> int:

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -118,6 +118,16 @@ class GenericSSLDataset(Dataset):
         )
         return cfg["DATA"][split].get("DATA_LIMIT_SAMPLING", default_sampling)
 
+    def set_epoch(self, epoch):
+        for data_obj in self.data_objs:
+            if hasattr(data_obj, "set_epoch"):
+                data_obj.set_epoch(epoch)
+
+    def set_start_iter(self, start_iter):
+        for data_obj in self.data_objs:
+            if hasattr(data_obj, "set_start_iter"):
+                data_obj.set_start_iter(start_iter)
+
     def _verify_data_sources(self, split, dataset_source_map):
         """
         For each data source, verify that the specified data source

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -118,16 +118,6 @@ class GenericSSLDataset(Dataset):
         )
         return cfg["DATA"][split].get("DATA_LIMIT_SAMPLING", default_sampling)
 
-    def set_epoch(self, epoch):
-        for data_obj in self.data_objs:
-            if hasattr(data_obj, "set_epoch"):
-                data_obj.set_epoch(epoch)
-
-    def set_start_iter(self, start_iter):
-        for data_obj in self.data_objs:
-            if hasattr(data_obj, "set_start_iter"):
-                data_obj.set_start_iter(start_iter)
-
     def _verify_data_sources(self, split, dataset_source_map):
         """
         For each data source, verify that the specified data source

--- a/vissl/hooks/state_update_hooks.py
+++ b/vissl/hooks/state_update_hooks.py
@@ -95,6 +95,11 @@ class SetDataSamplerEpochHook(ClassyHook):
             if hasattr(task.dataloaders[phase_type].sampler, "set_epoch"):
                 # task.phase_idx is current running phase id
                 task.dataloaders[phase_type].sampler.set_epoch(task.phase_idx)
+        if hasattr(task.dataloaders[phase_type], "dataset"):
+            if hasattr(task.dataloaders[phase_type].dataset, "set_epoch"):
+                # task.phase_idx is current running phase id
+                task.dataloaders[phase_type].dataset.set_epoch(task.phase_idx)
+
         logging.info(f"Starting phase {task.phase_idx} [{phase_type}]")
 
 

--- a/vissl/trainer/train_task.py
+++ b/vissl/trainer/train_task.py
@@ -492,7 +492,6 @@ class SelfSupervisionTask(ClassificationTask):
         num_train_iters_done = num_epochs * num_iters_in_epochs
         return self.checkpoint["iteration"] - num_train_iters_done
 
-
     def recreate_data_iterator(self, phase_type, epoch, compute_start_iter):
         """
         Recreate data iterator (including multiprocessing workers) and destroy the


### PR DESCRIPTION
I created a new type of dataset "airstore" on top of new AIRStore ioPath tabular interface. To make the check point resuming work, I need replicate the logic that set_epoch and set_start_iter on sampler, do the same thing for dataset objs.
I have tested it in faircluster
* doc for setup the integration:  https://docs.google.com/document/d/1RNSjJcFTGl4Or-9SRLYbB-ffuOMidZy62SwBA9L0Qm0/edit?usp=sharing
* example output (imagenet with config quick_simclr_2node): /checkpoint/wpc/vissl/2021-04-14-17-03-36/checkpoints/log.txt

