### PR TITLE
Make dataloaders configurable in anticipation for OnBoxDataloader integration

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -175,6 +175,8 @@ config:
       REMOVE_IMG_PATH_PREFIX: ""
       # what prefix to replace the old prefix with. Could stay empty too
       NEW_IMG_PATH_PREFIX: ""
+      # Pytorch opensource Dataloader to use for loading data.
+      DATALOADER: dataloader
       # name of the dataset. Meaningful and used to do lookup in the dataset_catalog.json
       # it has the advantage that user needs to full the dataset_catalog.json once
       # and then simply use the dataset name without having to specify data paths every time.
@@ -319,6 +321,8 @@ config:
       # what prefix to replace the old prefix with. Could stay empty too
       NEW_IMG_PATH_PREFIX: ""
       DROP_LAST: False
+      # Pytorch opensource Dataloader to use for loading data.
+      DATALOADER: dataloader
       DATA_SOURCES: []
       DATA_PATHS: []
       LABEL_SOURCES: []

--- a/vissl/data/dataloaders/dataloader_factory.py
+++ b/vissl/data/dataloaders/dataloader_factory.py
@@ -1,0 +1,24 @@
+from torch.utils.data import DataLoader
+from vissl.data.dataloaders.dataloader_factory_base import DataLoaderFactoryBase
+
+
+class DataLoaderFactory(DataLoaderFactoryBase):
+    """
+    Pytorch Default data loader factory.
+    """
+
+    def get_dataloader(self):
+        """
+        @return: Dataloader class instance.
+        """
+        return DataLoader(
+            dataset=self.dataset,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            shuffle=False,
+            batch_size=self.batch_size,
+            collate_fn=self.collate_fn,
+            sampler=self.sampler,
+            drop_last=self.drop_last,
+            worker_init_fn=self.worker_init_fn,
+        )

--- a/vissl/data/dataloaders/dataloader_factory_base.py
+++ b/vissl/data/dataloaders/dataloader_factory_base.py
@@ -1,0 +1,59 @@
+from abc import ABC
+
+
+class DataLoaderFactoryBase(ABC):
+    """
+    Abstract baseclass for dataloader factories. This abstraction is used to clean up the
+    fetching of the dataloaders, as different dataloaders require different arguments.
+
+    To implement a factory inherit from this class(DataLoaderFactoryBase) and overwrite the
+    #get_dataloader method. Any additional arguments needed in #get_dataloader should be added in
+    DataLoaderFactoryBase#__init__.
+    """
+
+    def __init__(
+        self,
+        dataloader_config,
+        dataset_config,
+        dataset,
+        num_workers,
+        pin_memory,
+        shuffle,
+        batch_size,
+        collate_fn,
+        sampler,
+        drop_last,
+        worker_init_fn,
+    ):
+        self.dataloader_config = dataloader_config
+        self.dataset_config = dataset_config
+        self.dataset = dataset
+        self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.shuffle = shuffle
+        self.batch_size = batch_size
+        self.collate_fn = collate_fn
+        self.sampler = sampler
+        self.drop_last = drop_last
+        self.worker_init_fn = worker_init_fn
+
+        self._validate_datasets()
+
+    def get_dataloader(self):
+        """
+        Required method for dataloader factory class.
+
+        @return: Dataloader class instance.
+        """
+        raise NotImplementedError
+
+    def _validate_datasets(self):
+        """
+        Validates that the data loader supports the dataset listed.
+        """
+        supported_datasets = self.dataloader_config["datasets"]
+        dataloader = self.dataloader_config["factory_class"]
+        for dataset in self.dataset_config["DATA_SOURCES"]:
+            assert (
+                dataset in supported_datasets
+            ), f"Dataset: { dataset } is not supported in data loader factory: { dataloader }"


### PR DESCRIPTION
Summary:
In anticipation for integrating the OnBoxDataLoader, we need to make the dataloader configurable. The idea is to use a factory class, to keep the logic in #get_loader concise.

I also propose we follow the same pattern as below for the dataset configuration, as we won't be able to use GenericSSLDataset for OnBoxDataLoader.

See https://fb.quip.com/587dAkUb7pyM for more information.

Differential Revision: D27888139

