### PR TITLE
Update numpy and pytorch seeding for dataloader and multiple processes per machine.

### DIFF
--- a/tools/perf_measurement/benchmark_data.py
+++ b/tools/perf_measurement/benchmark_data.py
@@ -30,6 +30,8 @@ def benchmark_data(cfg: AttrDict, split: str = "train"):
     except AttributeError:
         device = torch.device("cuda")
 
+    # Gives sampler same seed for entire distributed group as per pytorch documentation.
+    sampler_seed = cfg.SEED_VALUE
     dataloader = get_loader(
         dataset=dataset,
         dataset_config=cfg["DATA"][split],
@@ -37,6 +39,7 @@ def benchmark_data(cfg: AttrDict, split: str = "train"):
         pin_memory=False,
         multi_processing_method=cfg.MULTI_PROCESSING_METHOD,
         device=device,
+        sampler_seed=sampler_seed,
     )
 
     # Fairstore data sampler would require setting the start iter before it can start.

--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -23,7 +23,7 @@ from vissl.data.disk_dataset import DiskImageDataset
 from vissl.data.ssl_dataset import GenericSSLDataset
 from vissl.data.synthetic_dataset import SyntheticImageDataset
 from vissl.data.torchvision_dataset import TorchvisionDataset
-from vissl.utils.misc import setup_multiprocessing_method
+from vissl.utils.misc import setup_multiprocessing_method, set_dataloader_seeds
 
 
 __all__ = [
@@ -98,7 +98,7 @@ def print_sampler_config(data_sampler):
     logging.info("Distributed Sampler config:\n{}".format(sampler_cfg))
 
 
-def get_sampler(dataset, dataset_config):
+def get_sampler(dataset, dataset_config, sampler_seed=0):
     """
     Given the dataset object and the dataset config, get the data sampler to use
     Supports 2 types of samplers:
@@ -114,10 +114,14 @@ def get_sampler(dataset, dataset_config):
             )
         elif dataset_config["USE_STATEFUL_DISTRIBUTED_SAMPLER"]:
             data_sampler = StatefulDistributedSampler(
-                dataset, batch_size=dataset_config["BATCHSIZE_PER_REPLICA"]
+                dataset,
+                batch_size=dataset_config["BATCHSIZE_PER_REPLICA"],
+                seed=sampler_seed,
             )
         else:
-            data_sampler = torch.utils.data.distributed.DistributedSampler(dataset)
+            data_sampler = torch.utils.data.distributed.DistributedSampler(
+                dataset, seed=sampler_seed
+            )
         logging.info("Created the Distributed Sampler....")
         print_sampler_config(data_sampler)
     else:
@@ -140,8 +144,9 @@ def get_loader(
     pin_memory: bool,
     multi_processing_method: str,
     device: torch.device,
+    sampler_seed=0,
     get_sampler=get_sampler,
-    worker_init_fn=None,
+    worker_init_fn=set_dataloader_seeds,
 ):
     """
     Get the dataloader for the given satasets and data split
@@ -153,6 +158,7 @@ def get_loader(
         num_dataloader_workers (int):   number of workers per gpu (or cpu) training
         pin_memory (bool):              whether to pin memory or not
         multi_processing_method (str):  method to use. options: forkserver | fork | spawn
+        sampler_seed (int):             seed for the sampler. Should be identical per process
         device (torch.device):          training on cuda or cpu
         get_sampler (get_sampler):      function that is used to get the sampler
         worker_init_fn (None):          any function that should be executed during
@@ -169,7 +175,7 @@ def get_loader(
 
     # we don't need to set the rank, replicas as the Sampler already does so in
     # it's init function
-    data_sampler = get_sampler(dataset, dataset_config)
+    data_sampler = get_sampler(dataset, dataset_config, sampler_seed)
     collate_function = get_collator(
         dataset_config["COLLATE_FUNCTION"], dataset_config["COLLATE_FUNCTION_PARAMS"]
     )

--- a/vissl/data/data_helper.py
+++ b/vissl/data/data_helper.py
@@ -94,7 +94,7 @@ class StatefulDistributedSampler(DistributedSampler):
     we want to resume the data sampler from the training iteration.
     """
 
-    def __init__(self, dataset, batch_size=None):
+    def __init__(self, dataset, batch_size=None, seed: int = 0):
         """
         Initializes the instance of StatefulDistributedSampler. Random seed is set
         for the epoch set and data is shuffled. For starting the sampling, use
@@ -104,8 +104,9 @@ class StatefulDistributedSampler(DistributedSampler):
         Args:
             dataset (Dataset): Pytorch dataset that sampler will shuffle
             batch_size (int): batch size we want the sampler to sample
+            seed (int): Seed for the torch generator.
         """
-        super().__init__(dataset, shuffle=False)
+        super().__init__(dataset, shuffle=False, seed=seed)
 
         self.start_iter = 0
         self.batch_size = batch_size
@@ -116,7 +117,7 @@ class StatefulDistributedSampler(DistributedSampler):
     def __iter__(self):
         # partition data into num_replicas and optionally shuffle within a rank
         g = torch.Generator()
-        g.manual_seed(self.epoch)
+        g.manual_seed(self.epoch + self.seed)
         shuffling = torch.randperm(self.num_samples, generator=g).tolist()
         indices = np.array(
             list(

--- a/vissl/engines/train.py
+++ b/vissl/engines/train.py
@@ -76,7 +76,7 @@ def train_main(
 
     # set seeds
     logging.info("Setting seed....")
-    set_seeds(cfg, node_id)
+    set_seeds(cfg, dist_rank)
 
     # We set the CUDA device here as well as a safe solution for all downstream
     # `torch.cuda.current_device()` calls to return correct device.

--- a/vissl/trainer/train_task.py
+++ b/vissl/trainer/train_task.py
@@ -294,6 +294,9 @@ class SelfSupervisionTask(ClassificationTask):
         """
         self.datasets, self.data_and_label_keys = self.build_datasets()
 
+        # Gives sampler same seed for entire distributed group as per pytorch documentation.
+        sampler_seed = self.config["SEED_VALUE"]
+
         loaders = {
             split.lower(): get_loader(
                 dataset=self.datasets[split],
@@ -302,6 +305,7 @@ class SelfSupervisionTask(ClassificationTask):
                 pin_memory=pin_memory,
                 multi_processing_method=self.config.MULTI_PROCESSING_METHOD,
                 device=self.device,
+                sampler_seed=sampler_seed,
             )
             for split in self.available_splits
         }


### PR DESCRIPTION
Summary:
*Current state:*

Currently we set different seeds per-nodes, but the same seed among all training processes on a node. However, each of our Dataloader process seeds are all different each epoch, but non-deterministic.

*Proposed State:*

Different random number seeds for each dist_rank, and different, deterministic, for each Dataloader process seeds per epoch.

https://fb.quip.com/hVIcAahpVLo2

*Effects:*

Fixes randomization for a few losses, hooks, and trunks. Fixes randomization when using the Fork multiprocessing option for transformations. Fixes collapse of seeds to 0 when config seed set to 0.

There are 3 changes summarized as:
1. Use dist_rank instead of node_id for seeding training processes.
2. Create worker_init_fn to manually set numpy seed for dataloader workers.
3. Add knowledge of training process seed to sampler.

Differential Revision: D27784137

