### PR TITLE
Make linear transfer hive everstore compatible.

### DIFF
--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -204,19 +204,6 @@ def build_dataloader(
     return dataloader
 
 
-def build_dataloader_iterator(dataloader, **kwargs):
-    """
-    Get the dataloader iterator for the given datasets and data split
-
-    Args:
-        dataloader (Dataloader): the dataloader object.
-
-    Returns:
-        An iterable of the dataloader.
-    """
-    return iter(dataloader)
-
-
 def wrap_dataloader(dataloader, enable_async_gpu_copy: bool, device: torch.device):
     """
     If the targeted device is CUDA, set up async device copy:

--- a/vissl/data/collators/targets_one_hot_default_collator.py
+++ b/vissl/data/collators/targets_one_hot_default_collator.py
@@ -64,7 +64,6 @@ def targets_one_hot_default_collator(batch, num_classes: int):
     labels = [x["label"][0] for x in batch]
     output_labels = []
     for idx in range(data.shape[0]):
-        # import pdb; pdb.set_trace()
         output_labels.append(
             convert_to_one_hot(labels[idx][0], labels[idx][1], num_classes)
         )

--- a/vissl/data/ssl_dataset.py
+++ b/vissl/data/ssl_dataset.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Callable, Dict, Set
+from typing import Any, Callable, Dict, Set
 
 import numpy as np
 from classy_vision.generic.distributed_util import get_world_size
@@ -410,8 +410,21 @@ class GenericSSLDataset(VisslDatasetBase):
         """
         return self.get_batchsize_per_replica() * get_world_size()
 
-    def post_process_batch(self, batch_data):
+    def get_classy_state(self):
         """
-        Identity function. Other base datasets may need to #post_process_batch.
+        No-op method. Used with other datasets that need state.
         """
-        return batch_data
+        return {}
+
+    def set_classy_state(self, state: Dict[str, Any]):
+        """
+        No-op method. Used with other datasets that need state.
+        """
+        pass
+
+    def rebuild_dataloader(self):
+        """
+        Whether or not to rebuild the dataloader. This is called
+        after every training phase.
+        """
+        return False

--- a/vissl/data/vissl_dataset_base.py
+++ b/vissl/data/vissl_dataset_base.py
@@ -43,10 +43,3 @@ class VisslDatasetBase(abc.ABC):
         batch_size_per_replica * world_size
         """
         ...
-
-    @abc.abstractmethod
-    def post_process_batch(self, batch_data):
-        """
-        Post process batch after data iterator has returned.
-        """
-        ...

--- a/vissl/hooks/log_hooks.py
+++ b/vissl/hooks/log_hooks.py
@@ -386,14 +386,18 @@ class LogLossMetricsCheckpointHook(ClassyHook):
                             of phase or iteration at which checkpointing is being done
         """
         phase_idx = task.phase_idx
-        num_epochs = task.num_epochs
+        # num_train_phases = num_epochs * num_phases_per_epoch
+        # For OSS use, num_train_phases will be equal to num_epochs
+        num_train_phases = task.num_train_phases
 
         # check if we need to checkpoint this phase
         is_checkpointing_phase = is_checkpoint_phase(
-            mode_num, mode_frequency, train_phase_idx, num_epochs, mode
+            mode_num, mode_frequency, train_phase_idx, num_train_phases, mode
         )
         is_final_train_phase = (
-            (train_phase_idx == (num_epochs - 1)) and task.train and mode == "phase"
+            (train_phase_idx == (num_train_phases - 1))
+            and task.train
+            and mode == "phase"
         )
 
         # handle checkpoint:

--- a/vissl/trainer/train_steps/standard_train_step.py
+++ b/vissl/trainer/train_steps/standard_train_step.py
@@ -119,7 +119,6 @@ def standard_train_step(task):
     with PerfTimer("read_sample", perf_stats):
         sample = next(task.data_iterator)
 
-    sample = task.post_process_batch(sample)
     sample = construct_sample_for_model(sample, task)
 
     # Only need gradients during training

--- a/vissl/utils/checkpoint.py
+++ b/vissl/utils/checkpoint.py
@@ -462,7 +462,11 @@ def get_checkpoint_folder(config: AttrDict):
 
 
 def is_checkpoint_phase(
-    mode_num: int, mode_frequency: int, train_phase_idx: int, num_epochs: int, mode: str
+    mode_num: int,
+    mode_frequency: int,
+    train_phase_idx: int,
+    num_train_phases: int,
+    mode: str,
 ):
     """
     Determines if a checkpoint should be saved on current epoch. If epoch=1, then
@@ -476,7 +480,7 @@ def is_checkpoint_phase(
                         checkpoint at.
         mode_frequency (int): checkpoint frequency - every N iterations or every N epochs/phase
         train_phase_idx (int): the current training phase we are in. Starts from 0
-        num_epochs (int): total number of epochs in training
+        num_train_phases (int): total number of training phases. Usually the same as num_epochs.
 
     Returns:
         checkpointing_phase (bool): whether the model should be checkpointed or not
@@ -485,7 +489,7 @@ def is_checkpoint_phase(
         checkpointing_phase = (mode_num % mode_frequency) == 0
     elif mode == "phase":
         checkpointing_phase = (mode_num % mode_frequency) == 0 or train_phase_idx == (
-            num_epochs - 1
+            num_train_phases - 1
         )
     return checkpointing_phase
 

--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -567,3 +567,8 @@ def infer_and_assert_hydra_config(cfg):
     # Delete the AUTO_SETUP_FSDP key since we send the FSDP_CONFIG
     # to FSDP from fairscale which doesn't know about AUTO_SETUP_FSDP
     del cfg.MODEL.FSDP_CONFIG["AUTO_SETUP_FSDP"]
+
+    if cfg.DATA.TRAIN.BASE_DATASET == "generic_ssl":
+        assert (
+            cfg.DATA.TRAIN.get("TRAIN_PHASES_PER_EPOCH", 1) == 1
+        ), "When using the generic_ssl, we must set TRAIN_PHASES_PER_EPOCH = 1."


### PR DESCRIPTION
Summary:
1. Use OnBoxDatloader transforms to call the collate_fn instead of #post_process_batch, as we were running into some OOM as well as latency issues using #post_process_batch.

1. Use train_phase_idx instead of phase_idx for setting dataloader iterator. Classy enforces the next phase to be 1 + last_phase. When interleaving test/train and using phase_idx, this is not the case.

1. Implement workaround for classy/pytorch dataloader issues as described [here](https://fb.workplace.com/groups/classyvision/permalink/3916345991735902/). Workaround specifies both dataloaders as "train". Note that for train and test the last batch will be dropped if it is < batch_size.
1. Add the ability to have multiple phases per epoch (just for Hive).

Differential Revision: D28443537

