### PR TITLE
Move hydra dict conversions before saving dict to disk

### DIFF
--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -52,8 +52,8 @@ def convert_to_attrdict(cfg: DictConfig, cmdline_args: List[Any] = None):
     # assert the config and infer
     config = cfg.config
     infer_and_assert_hydra_config(config)
-    save_attrdict_to_disk(config)
     convert_fsdp_dtypes(config)
+    save_attrdict_to_disk(config)
     return cfg, config
 
 


### PR DESCRIPTION
We should be saving the final config file on disk that is used by training and not have any changes after it's saved. 