### PR TITLE
Remove default slurm partition option

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -1167,8 +1167,8 @@ config:
     NAME: "vissl"
     # Comment of the job on SLURM
     COMMENT: "vissl job"
-    # Partition of SLURM on which to run the job
-    PARTITION: "learnfair"
+    # Partition of SLURM on which to run the job. This is a required field if using SLURM.
+    PARTITION: ""
     # Where the logs produced by the SLURM jobs will be output
     LOG_FOLDER: "."
     # Maximum number of hours / minutes needed by the job to complete. Above this limit, the job might be pre-empted.

--- a/vissl/utils/distributed_launcher.py
+++ b/vissl/utils/distributed_launcher.py
@@ -255,6 +255,7 @@ def launch_distributed_on_slurm(cfg: AttrDict, engine_name: str):
     assert PathManager.exists(
         log_folder
     ), f"Specified config.SLURM.LOG_FOLDER={log_folder} doesn't exist"
+    assert cfg.SLURM.PARTITION, "SLURM.PARTITION must be set when using SLURM"
 
     executor = submitit.AutoExecutor(folder=log_folder)
     timeout_min = cfg.SLURM.TIME_HOURS * 60 + cfg.SLURM.TIME_MINUTES


### PR DESCRIPTION
 I am a bit worried this may break somebody's workflow? We might want to have our own internal defaults in order to ensure backwards compatability. 