### PR TITLE
Fix seed regression, as option is not available in prev pytorch version

### DIFF
--- a/vissl/data/__init__.py
+++ b/vissl/data/__init__.py
@@ -122,9 +122,7 @@ def get_sampler(dataset, dataset_config, sampler_seed=0):
                 seed=sampler_seed,
             )
         else:
-            data_sampler = torch.utils.data.distributed.DistributedSampler(
-                dataset, seed=sampler_seed
-            )
+            data_sampler = torch.utils.data.distributed.DistributedSampler(dataset)
         logging.info("Created the Distributed Sampler....")
         print_sampler_config(data_sampler)
     else:

--- a/vissl/engines/extract_features.py
+++ b/vissl/engines/extract_features.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 
 from vissl.config import AttrDict
 from vissl.trainer import SelfSupervisionTrainer
@@ -49,7 +50,8 @@ def extract_main(
 
     # set seeds
     logging.info("Setting seed....")
-    set_seeds(cfg)
+    dist_rank = int(os.environ["RANK"])
+    set_seeds(cfg, dist_rank)
 
     # print the training settings and system settings
     local_rank, _ = get_machine_local_and_dist_rank()


### PR DESCRIPTION
Our recommended pytorch version does not have seed available as an option for `torch.utils.data.distributed.DistributedSampler`. This was breaking master for me in distributed training on SLURM. 