### PR TITLE
Make convert_sharded_checkpoints fbcode compatible

### DIFF
--- a/extra_scripts/convert_sharded_checkpoint.py
+++ b/extra_scripts/convert_sharded_checkpoint.py
@@ -18,8 +18,15 @@ Example:
 
 import argparse
 import enum
+import os
 
+from fvcore.common.file_io import PathManager
+from hydra.experimental import compose, initialize_config_module
+from vissl.config import AttrDict
 from vissl.utils.checkpoint import CheckpointFormatConverter
+from vissl.utils.env import set_env_vars
+from vissl.utils.hydra_config import convert_to_attrdict
+from vissl.utils.io import makedir
 from vissl.utils.logger import setup_logging, shutdown_logging
 
 
@@ -37,6 +44,13 @@ class CheckpointType(enum.Enum):
 
 
 def convert_checkpoint(input_path: str, output_path: str, output_type: str):
+    assert PathManager.exists(
+        input_path
+    ), f"Checkpoint input path: {input_path} not found."
+
+    # Make the output directory if it doesn't exist.
+    makedir(os.path.split(output_path)[0])
+
     setup_logging(__name__)
     if output_type == CheckpointType.consolidated.name:
         CheckpointFormatConverter.sharded_to_consolidated_checkpoint(
@@ -45,6 +59,20 @@ def convert_checkpoint(input_path: str, output_path: str, output_type: str):
     elif output_type == CheckpointType.sliced.name:
         CheckpointFormatConverter.sharded_to_sliced_checkpoint(input_path, output_path)
     shutdown_logging()
+
+
+def setup_pathmanager():
+    """
+    Setup PathManager. A bit hacky -- we use the #set_env_vars method to setup pathmanager
+    and as such we need to create a dummy config, and dummy values for local_rank and node_id.
+    """
+    with initialize_config_module(config_module="vissl.config"):
+        cfg = compose(
+            "defaults",
+            overrides=["config=test/integration_test/quick_swav"],
+        )
+    config = AttrDict(cfg).config
+    set_env_vars(local_rank=0, node_id=0, cfg=config)
 
 
 if __name__ == "__main__":
@@ -59,4 +87,7 @@ if __name__ == "__main__":
         help=f"Output format of the checkpoint ({CheckpointType.consolidated.name}, {CheckpointType.sliced.name})",
     )
     args = parser.parse_args()
+
+    setup_pathmanager()
+
     convert_checkpoint(args.input, args.output, args.type)


### PR DESCRIPTION
Summary:
Some basic changes to make this script work within FBinfra.

1. Register Manifold in PathManager.
1. In order to do #1, create fb/extra_scripts/convert_sharded_checkpoint.y and add necessary dependencies in TARGETS
1. Replace some torch.loads using PathManager.

Differential Revision: D29166520

