### PR TITLE
Update default moco log frequency

### DIFF
--- a/configs/config/pretrain/moco/moco_1node_resnet.yaml
+++ b/configs/config/pretrain/moco/moco_1node_resnet.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 config:
   VERBOSE: False
-  LOG_FREQUENCY: 10
+  LOG_FREQUENCY: 200
   TEST_ONLY: False
   TEST_MODEL: False
   SEED_VALUE: 0


### PR DESCRIPTION
Summary: Updated default moco tensorboard log frequency to be every 200 iters compared to original 10 iters. 10 iters causes very slow training on FBL (see test plan).

Reviewed By: iseessel

Differential Revision: D29234726

