### PR TITLE
Make extra_scripts/datasets fbinfra compatible

### DIFF
--- a/extra_scripts/datasets/create_clevr_count_data_files.py
+++ b/extra_scripts/datasets/create_clevr_count_data_files.py
@@ -8,8 +8,8 @@ import json
 import os
 
 import numpy as np
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_clevr_dist_data_files.py
+++ b/extra_scripts/datasets/create_clevr_dist_data_files.py
@@ -9,8 +9,8 @@ import json
 import os
 
 import numpy as np
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_dsprites_location_data_files.py
+++ b/extra_scripts/datasets/create_dsprites_location_data_files.py
@@ -10,8 +10,8 @@ from typing import Set
 import numpy as np
 from PIL import Image
 from torch.utils.data import DataLoader, Dataset
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_dtd_data_files.py
+++ b/extra_scripts/datasets/create_dtd_data_files.py
@@ -7,8 +7,8 @@ import argparse
 import os
 import shutil
 
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_euro_sat_data_files.py
+++ b/extra_scripts/datasets/create_euro_sat_data_files.py
@@ -8,8 +8,8 @@ import os
 import shutil
 
 from torch.utils.data import DataLoader
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_fgvc_aircraft_data_files.py
+++ b/extra_scripts/datasets/create_fgvc_aircraft_data_files.py
@@ -7,8 +7,8 @@ import argparse
 import os
 import shutil
 
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_food101_data_files.py
+++ b/extra_scripts/datasets/create_food101_data_files.py
@@ -8,8 +8,8 @@ import os
 
 from PIL import Image
 from torch.utils.data import DataLoader
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_gtsrb_data_files.py
+++ b/extra_scripts/datasets/create_gtsrb_data_files.py
@@ -8,8 +8,8 @@ import os
 import shutil
 from typing import List, Tuple
 
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_imagenet_ood_data_files.py
+++ b/extra_scripts/datasets/create_imagenet_ood_data_files.py
@@ -9,8 +9,8 @@ import os
 import numpy as np
 import torchvision.datasets as datasets
 from fvcore.common.file_io import PathManager
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_inaturalist2018_data_files.py
+++ b/extra_scripts/datasets/create_inaturalist2018_data_files.py
@@ -21,7 +21,7 @@ import sys
 
 import numpy as np
 from fvcore.common.file_io import PathManager
-from torchvision.datasets.utils import download_and_extract_archive
+from vissl.utils.download import download_and_extract_archive
 from vissl.utils.io import save_file
 
 

--- a/extra_scripts/datasets/create_kitti_dist_data_files.py
+++ b/extra_scripts/datasets/create_kitti_dist_data_files.py
@@ -12,8 +12,8 @@ from typing import Set
 
 import numpy as np
 from torch.utils.data import DataLoader
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_oxford_flowers_data_files.py
+++ b/extra_scripts/datasets/create_oxford_flowers_data_files.py
@@ -9,8 +9,8 @@ import shutil
 
 import numpy as np
 import scipy.io
-from torchvision.datasets.utils import download_and_extract_archive, download_url
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive, download_url
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_oxford_pets_data_files.py
+++ b/extra_scripts/datasets/create_oxford_pets_data_files.py
@@ -7,8 +7,8 @@ import argparse
 import os
 import shutil
 
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_patch_camelyon_data_files.py
+++ b/extra_scripts/datasets/create_patch_camelyon_data_files.py
@@ -10,8 +10,8 @@ from typing import NamedTuple
 
 from PIL import Image
 from torch.utils.data import DataLoader
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 try:

--- a/extra_scripts/datasets/create_small_norb_elevation_data_files.py
+++ b/extra_scripts/datasets/create_small_norb_elevation_data_files.py
@@ -8,8 +8,8 @@ import os
 
 import numpy as np
 from PIL import Image
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_stanford_cars_data_files.py
+++ b/extra_scripts/datasets/create_stanford_cars_data_files.py
@@ -9,8 +9,8 @@ import shutil
 
 from scipy import io
 from torch.utils.data import DataLoader
-from torchvision.datasets.utils import download_and_extract_archive, download_url
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive, download_url
 
 
 def get_argument_parser():

--- a/extra_scripts/datasets/create_sun397_data_files.py
+++ b/extra_scripts/datasets/create_sun397_data_files.py
@@ -11,8 +11,8 @@ from typing import Any, List
 
 import numpy as np
 from fvcore.common.file_io import PathManager
-from torchvision.datasets.utils import download_and_extract_archive
 from tqdm import tqdm
+from vissl.utils.download import download_and_extract_archive
 
 
 @dataclasses.dataclass

--- a/vissl/utils/download.py
+++ b/vissl/utils/download.py
@@ -5,6 +5,18 @@
 
 import io
 import os
+import re
+import urllib
+import urllib.error
+import urllib.request
+from typing import Optional
+from urllib.parse import urlparse
+
+from torch.utils.model_zoo import tqdm
+from torchvision.datasets.utils import (
+    check_integrity,
+    extract_archive,
+)
 
 
 def get_redirected_url(url: str):
@@ -71,3 +83,106 @@ def download_google_drive_url(url: str, output_path: str, output_file_name: str)
                     ):
                         file.write(block)
                         progress_bar.update(len(block))
+
+
+def _get_google_drive_file_id(url: str) -> Optional[str]:
+    parts = urlparse(url)
+
+    if re.match(r"(drive|docs)[.]google[.]com", parts.netloc) is None:
+        return None
+
+    match = re.match(r"/file/d/(?P<id>[^/]*)", parts.path)
+    if match is None:
+        return None
+
+    return match.group("id")
+
+
+# These are copied from torchvision, with some minor adjustments for VISSL support.
+def download_url(
+    url: str,
+    root: str,
+    filename: Optional[str] = None,
+    md5: Optional[str] = None,
+) -> None:
+    """Download a file from a url and place it in root.
+
+    Args:
+        url (str): URL to download file from
+        root (str): Directory to place downloaded file in
+        filename (str, optional): Name to save the file under.
+                                  If None, use the basename of the URL.
+        md5 (str, optional): MD5 checksum of the download. If None, do not check
+    """
+    root = os.path.expanduser(root)
+    if not filename:
+        filename = os.path.basename(url)
+    fpath = os.path.join(root, filename)
+
+    os.makedirs(root, exist_ok=True)
+
+    # check if file is already present locally
+    if check_integrity(fpath, md5):
+        print("Using downloaded and verified file: " + fpath)
+        return
+
+    # expand redirect chain if needed
+    url = get_redirected_url(url)
+
+    # check if file is located on Google Drive
+    file_id = _get_google_drive_file_id(url)
+    if file_id is not None:
+        return download_google_drive_url(file_id, root, filename, md5)
+
+    # download the file
+    try:
+        print("Downloading " + url + " to " + fpath)
+        _urlretrieve(url, fpath)
+    except (urllib.error.URLError, IOError) as e:  # type: ignore[attr-defined]
+        if url[:5] == "https":
+            url = url.replace("https:", "http:")
+            print(
+                "Failed download. Trying https -> http instead."
+                " Downloading " + url + " to " + fpath
+            )
+            _urlretrieve(url, fpath)
+        else:
+            raise e
+
+    # check integrity of downloaded file
+    if not check_integrity(fpath, md5):
+        raise RuntimeError("File not found or corrupted.")
+
+
+def _urlretrieve(url: str, filename: str, chunk_size: int = 1024) -> None:
+    with open(filename, "wb") as fh:
+        with urllib.request.urlopen(
+            urllib.request.Request(url, headers={"User-Agent": "vissl"})
+        ) as response:
+            with tqdm(total=response.length) as pbar:
+                for chunk in iter(lambda: response.read(chunk_size), ""):
+                    if not chunk:
+                        break
+                    pbar.update(chunk_size)
+                    fh.write(chunk)
+
+
+def download_and_extract_archive(
+    url: str,
+    download_root: str,
+    extract_root: Optional[str] = None,
+    filename: Optional[str] = None,
+    md5: Optional[str] = None,
+    remove_finished: bool = False,
+) -> None:
+    download_root = os.path.expanduser(download_root)
+    if extract_root is None:
+        extract_root = download_root
+    if not filename:
+        filename = os.path.basename(url)
+
+    download_url(url, download_root, filename, md5)
+
+    archive = os.path.join(download_root, filename)
+    print("Extracting {} to {}".format(archive, extract_root))
+    extract_archive(archive, extract_root, remove_finished)


### PR DESCRIPTION
Summary:
This diff:
1. Create bash script for running the extra_scripts. Requires setting up proxies to download external datasets.
1. Create TARGETS for extra scripts to create python binary.
1. Copy/past torchvision `download_and_extract` and adapt code slightly to work in VISSL. When calling  `download_and_extract` from fbcode, it will only search in Manifold. See: https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/pytorch/vision/torchvision/datasets/utils.py?commit=614d91a67054&lines=125

Next steps for followup diff include:
1. Augmenting script to automatically upload to manifold and delete files locally after upload  (Maybe, depends on how standardized outputs of extra_scripts are).
1. Adding script to modify .npy files to MANIFOLD paths (this may be taken care of by the following?)

```
    config.DATA.TRAIN.REMOVE_IMG_PATH_PREFIX='manifold://' \
    config.DATA.TRAIN.NEW_IMG_PATH_PREFIX='memcache_manifold://'
```

Differential Revision: D29337221

