### PR TITLE
Add helper function in order to setup the path manager without having to setup the local rank

### DIFF
--- a/vissl/utils/env.py
+++ b/vissl/utils/env.py
@@ -31,6 +31,15 @@ def set_env_vars(local_rank: int, node_id: int, cfg: AttrDict):
         os.environ["NCCL_SOCKET_NTHREADS"] = str(cfg.DISTRIBUTED.NCCL_SOCKET_NTHREADS)
 
 
+def setup_path_manager():
+    """
+    Registering the right options for the PathManager:
+    Override this function in your build system to
+    support different distributed file system
+    """
+    pass
+
+
 def print_system_env_info(current_env):
     """
     Print information about user system environment where VISSL is running.


### PR DESCRIPTION
Summary: For scripts needing a way to work on FB Code with Manifold but not requiring any of the other features of set_env_vars

Differential Revision: D29463919

