### PR TITLE
Support multi-output for test set.

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -355,6 +355,12 @@ config:
       # In case of an invalid image, by default a mean image is returned. But using
       # QueueDataset, you can instead return a valid and previously seen image.
       ENABLE_QUEUE_DATASET: False
+      # Whether or not a single example has more than one label.
+      MULTI_LABEL: False
+      # Implementation detail for multi-output, we need to specify the number of classes in
+      # the dataset, as the transformation does not have access to the number of classes.
+      # This can be improved.
+      MULTI_LABEL_NUM_CLASSES: 1000
     TEST:
       # A sampler that cuts the dataset in a deterministic way
       USE_DEBUGGING_SAMPLER: False
@@ -397,6 +403,12 @@ config:
       # In case of an invalid image, by default a mean image is returned. But using
       # QueueDataset, you can instead return a valid and previously seen image.
       ENABLE_QUEUE_DATASET: False
+      # Whether or not a single example has more than one label.
+      MULTI_LABEL: False
+      # Implementation detail for multi-output, we need to specify the number of classes in
+      # the dataset, as the transformation does not have access to the number of classes.
+      # This can be improved.
+      MULTI_LABEL_NUM_CLASSES: 1000
 
   # ----------------------------------------------------------------------------------- #
   # METERS

--- a/vissl/data/ssl_transforms/multi_label_transform.py
+++ b/vissl/data/ssl_transforms/multi_label_transform.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Any
+
+import torch
+from classy_vision.dataset.transforms import register_transform
+from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+
+
+@register_transform("MultiLabelTransform")
+class MultiLabelTransform(ClassyTransform):
+    """
+    Prepare labels for multi-output support. That is when a single example has
+    more than one label. Currently all that this transform does is one-hot encodes
+    the labels. This is because the Classy accuracy meters already expects the labels
+    to be one-hot encoded when in a multi-output mode.
+    """
+
+    def __init__(self, num_classes: int = 1000):
+        """
+        Args:
+            num_classes (int): how many classes there are in total. Default 1000 for imagenet1k.
+        """
+        super().__init__()
+
+        self.num_classes = num_classes
+
+    def __call__(self, batch: Dict[str, Any]):
+        """
+        Args:
+            batch (Dict[Str, Any]). Where batch["label"] is an array of tensors of ints.
+            E.g. batch["label"] == [tensor([1, 2]), tensor([0])], means that the first
+            example has labels 1 and 2 and second example has label 0.
+        """
+        # One hot encode the labels.
+        for sample in batch:
+            for idx, labels in enumerate(sample["label"]):
+                sample["label"][idx] = self._one_hot_encode(labels)
+
+        return batch
+
+    def _one_hot_encode(self, labels):
+        # Create tensor of dim (num_classes).
+        one_hot_encoded = torch.zeros(
+            (self.num_classes), dtype=torch.long, device=labels.device
+        )
+
+        # Change 0 to 1 for all labels.
+        one_hot_encoded = one_hot_encoded.scatter_(0, labels, 1)
+
+        return one_hot_encoded

--- a/vissl/data/ssl_transforms/ssl_transforms_wrapper.py
+++ b/vissl/data/ssl_transforms/ssl_transforms_wrapper.py
@@ -19,7 +19,7 @@ _TRANSFORMS_WITH_COPIES = [
     "ImgPilToMultiCrop",
 ]
 _TRANSFORMS_WITH_GROUPING = ["ImgPilMultiCropRandomApply"]
-_TRANSFORMS_WITH_OVERWRITE_ENTIRE_BATCH = []
+_TRANSFORMS_WITH_OVERWRITE_ENTIRE_BATCH = ["MultiLabelTransform"]
 
 DEFAULT_TRANSFORM_TYPES = {
     "TRANSFORMS_WITH_LABELS": _TRANSFORMS_WITH_LABELS,
@@ -150,10 +150,7 @@ class SSLTransformsWrapper(ClassyTransform):
         Apply each transform on the specified indices of each entry in
         the input sample or batch.
         """
-        if (
-            self.transform_receives_entire_batch
-            and self._is_overwrite_entire_batch_transform()
-        ):
+        if self._is_overwrite_entire_batch_transform():
             # Transform the entire batch. This is currently only used for hive dataset.
             batch_or_img = self.transform(batch_or_img)
         elif self.transform_receives_entire_batch:

--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -577,3 +577,15 @@ def infer_and_assert_hydra_config(cfg):
         assert (
             cfg.DATA.TRAIN.get("TRAIN_PHASES_PER_EPOCH", 1) == 1
         ), "When using the generic_ssl, we must set TRAIN_PHASES_PER_EPOCH = 1."
+
+    # Implementation detail. Add the MultiLabelTransform with the number of classes. This will
+    # one-hot encode all the labels before passing to the loss/accuracy meter.
+    for split in ["TRAIN", "TEST"]:
+        dataset_config = cfg.DATA[split]
+        if dataset_config.MULTI_LABEL:
+            transform = {
+                "name": "MultiLabelTransform",
+                "num_classes": dataset_config.MULTI_LABEL_NUM_CLASSES,
+            }
+
+            dataset_config.TRANSFORMS.insert(0, transform)


### PR DESCRIPTION
Summary: 1. Support multi-output support. We do this by adding a transform that one-hot encodes the labels.

Differential Revision: D29699955

