### PR TITLE
ssl-framework: future compatibility with Hydra 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 cython==0.29.22
 fairscale@https://github.com/facebookresearch/fairscale/tarball/df7db85cef7f9c30a5b821007754b96eb1f977b6
 fvcore==0.1.3.post20210317
-hydra-core==1.0.6
+hydra-core==1.0.7
 numpy==1.19.5
 parameterized==0.7.4
 scikit-learn==0.24.1

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -33,6 +33,7 @@
 #        +config/pretrain/simclr/my_sub_folder=my_file_name \
 #        +config.MY_NEW_KEY=MY_VALUE
 defaults:
+  - _self_
   # you must specify the base config you want to run
   - config: ???
 


### PR DESCRIPTION
Summary:
One of the changes in Hydra 1.1 is that the default composition order is changing.
This is documented [here](https://hydra.cc/docs/upgrades/1.0_to_1.1/default_composition_order).
In Hydra 1.1, a config is overriding values introduced by the defaults list while in Hydra 1.0 - the defaults list was overriding the values in the config.

ssl framework is currently depending on the previous behavior in it's default.yaml config (expecting the defaults list to override it).

The solution is to add `_self_` as the first item in the defaults list.

#### Hydra 1.0
As of Hydra 1.0.7, Hydra 1.0 ignores `_self_` in the defaults list. Adding it there does not change the behavior of Hydra 1.0.

### Hydra 1.1
In Hydra 1.1, `_self_` determines the composition order of the content of a config relative to the items from its defaults list.
Adding `_self_` as the first item ensures that the defaults list will override the config and not the other way around.

Notes:
1. There could be other issues I am not yet aware of with Hydra 1.1. This is a first attempt to fix things.
2. The minimum Hydra version with this fix should be 1.0.7 (which is already on fbcode). [Hydra 1.0.7](https://github.com/facebookresearch/hydra/releases/tag/v1.0.7) is a maintenance release intended to make the migration to Hydra 1.1 easier and does not make significant changes.

Differential Revision: D29778452

