### PR TITLE
Fix FB Learner issue: OmegaConf code adaptations

### DIFF
--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -87,7 +87,12 @@ def print_cfg(cfg):
     """
     logging.info("Training with config:")
     if isinstance(cfg, DictConfig):
-        logging.info(cfg.pretty())
+        if hasattr(cfg, "pretty"):
+            # Backward compatibility
+            logging.info(cfg.pretty())
+        else:
+            # Newest version of OmegaConf
+            logging.info(OmegaConf.to_yaml(cfg))
     else:
         logging.info(pprint.pformat(cfg))
 


### PR DESCRIPTION
Summary: Make sure we can run jobs with FB Learner by correcting OmegaConf error due to "pretty()" being deprecated in newest versions

Differential Revision: D29791967

