### PR TITLE
Fix gem logic, reverse cropping/transformation order.

### DIFF
--- a/tools/instance_retrieval_test.py
+++ b/tools/instance_retrieval_test.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 import sys
 import uuid
 from argparse import Namespace
@@ -13,12 +14,15 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import torchvision
-from classy_vision.generic.util import copy_model_to_gpu
+from classy_vision.generic.util import copy_model_to_gpu, load_checkpoint
 from fvcore.common.file_io import PathManager
 from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.models import build_model
-from vissl.utils.checkpoint import init_model_from_consolidated_weights
+from vissl.utils.checkpoint import (
+    init_model_from_consolidated_weights,
+    get_checkpoint_folder,
+)
 from vissl.utils.env import set_env_vars
 from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available, print_cfg
 from vissl.utils.instance_retrieval_utils.data_util import (
@@ -53,7 +57,7 @@ def build_retrieval_model(cfg):
     if PathManager.exists(cfg.MODEL.WEIGHTS_INIT.PARAMS_FILE):
         init_weights_path = cfg.MODEL.WEIGHTS_INIT.PARAMS_FILE
         logging.info(f"Initializing model from: {init_weights_path}")
-        weights = torch.load(init_weights_path, map_location=torch.device("cuda"))
+        weights = load_checkpoint(init_weights_path, device=torch.device("cuda"))
         skip_layers = cfg.MODEL.WEIGHTS_INIT.get("SKIP_LAYERS", [])
         replace_prefix = cfg.MODEL.WEIGHTS_INIT.get("REMOVE_PREFIX", None)
         append_prefix = cfg.MODEL.WEIGHTS_INIT.get("APPEND_PREFIX", None)
@@ -83,7 +87,7 @@ def gem_pool_and_save_features(features, p, add_bias, gem_out_fname):
     else:
         logging.info(f"GeM pooling features: {features.shape}")
         features = l2n(gem(features, p=p, add_bias=True))
-        save_file(features, gem_out_fname)
+        save_file(features, gem_out_fname, log=False)
         logging.info(f"Saved GeM features to: {gem_out_fname}")
     return features
 
@@ -123,14 +127,19 @@ def get_train_features(
             # we can perform: rmac | gem pooling | l2 norm
             if cfg.IMG_RETRIEVAL.FEATS_PROCESSING_TYPE == "rmac":
                 descriptors = get_rmac_descriptors(activation_map, spatial_levels)
+            elif cfg.IMG_RETRIEVAL.FEATS_PROCESSING_TYPE == "l2_norm":
+                # we simply L2 normalize the features otherwise
+                descriptors = F.normalize(activation_map, p=2, dim=0)
             else:
                 descriptors = activation_map
-            save_file(descriptors.data.numpy(), fname_out)
+            save_file(descriptors.data.numpy(), fname_out, log=False)
             train_features.append(descriptors.data.numpy())
 
     num_images = train_dataset.get_num_images()
     out_dir = f"{temp_dir}/{train_dataset_name}_S{resize_img}_features_train"
     makedir(out_dir)
+
+    logging.info(f"Getting features for train images: {num_images}")
     for i in range(num_images):
         process_train_image(i, out_dir)
 
@@ -165,10 +174,13 @@ def process_eval_image(
         img = image_helper.load_and_prepare_instre_image(fname_in)
     else:
         img = image_helper.load_and_prepare_image(fname_in, roi=roi)
+
     v = torch.autograd.Variable(img.unsqueeze(0))
     vc = v.cuda()
     # the model output is a list always.
     activation_map = model(vc)[0].cpu()
+    print(f"Activation map shape: {activation_map.shape}")
+
     # process the features: rmac | l2 norm
     if cfg.IMG_RETRIEVAL.FEATS_PROCESSING_TYPE == "rmac":
         descriptors = get_rmac_descriptors(activation_map, spatial_levels, pca=pca)
@@ -177,7 +189,7 @@ def process_eval_image(
         descriptors = F.normalize(activation_map, p=2, dim=0)
     else:
         descriptors = activation_map
-    save_file(descriptors.data.numpy(), fname_out)
+    save_file(descriptors.data.numpy(), fname_out, log=False)
     return descriptors.data.numpy()
 
 
@@ -231,7 +243,7 @@ def get_dataset_features(
         )
         features_dataset = pca.apply(features_dataset)
     features_dataset = np.vstack(features_dataset)
-    logging.info(f"features dataset: {features_dataset.shape}")
+    logging.info(f"Dataset Features Size: {features_dataset.shape}")
     return features_dataset
 
 
@@ -249,7 +261,7 @@ def get_queries_features(
     features_queries = []
     num_queries = eval_dataset.get_num_query_images()
     if cfg.IMG_RETRIEVAL.DEBUG_MODE:
-        num_queries = 50
+        num_queries = 10
     logging.info(f"Getting features for queries: {num_queries}")
     q_fname_out_dir = "{}/{}_S{}_q".format(temp_dir, eval_dataset_name, resize_img)
     makedir(q_fname_out_dir)
@@ -288,7 +300,7 @@ def get_queries_features(
         )
         features_queries = pca.apply(features_queries)
     features_queries = np.vstack(features_queries)
-    logging.info(f"features queries: {features_queries.shape}")
+    logging.info(f"Queries Features Size: {features_queries.shape}")
     return features_queries
 
 
@@ -328,7 +340,7 @@ def get_train_dataset(cfg, root_dataset_path, train_dataset_name, eval_binary_pa
 
         if is_revisited_dataset(train_dataset_name):
             train_dataset = RevisitedInstanceRetrievalDataset(
-                train_dataset_name, root_dataset_path
+                train_dataset_name, root_dataset_path, num_samples=num_samples
             )
         elif is_whiten_dataset(train_dataset_name):
             train_dataset = WhiteningTrainingImageDataset(
@@ -349,11 +361,11 @@ def get_eval_dataset(cfg, root_dataset_path, eval_dataset_name, eval_binary_path
     eval_data_path = f"{root_dataset_path}/{eval_dataset_name}"
     assert PathManager.exists(eval_data_path), f"Unknown path: {eval_data_path}"
 
-    num_samples = 20 if cfg.IMG_RETRIEVAL.DEBUG_MODE else None
+    num_samples = 50 if cfg.IMG_RETRIEVAL.DEBUG_MODE else None
 
     if is_revisited_dataset(eval_dataset_name):
         eval_dataset = RevisitedInstanceRetrievalDataset(
-            eval_dataset_name, root_dataset_path
+            eval_dataset_name, root_dataset_path, num_samples=num_samples
         )
     elif is_instre_dataset(eval_dataset_name):
         eval_dataset = InstreDataset(eval_data_path, num_samples=num_samples)
@@ -374,7 +386,12 @@ def instance_retrieval_test(args, cfg):
     resize_img = cfg.IMG_RETRIEVAL.RESIZE_IMG
     eval_binary_path = cfg.IMG_RETRIEVAL.EVAL_BINARY_PATH
     root_dataset_path = cfg.IMG_RETRIEVAL.DATASET_PATH
+    save_results = cfg.IMG_RETRIEVAL.SAVE_RESULTS
+
     temp_dir = f"{cfg.IMG_RETRIEVAL.TEMP_DIR}/{str(uuid.uuid4())}"
+    if save_results:
+        temp_dir = os.path.join(get_checkpoint_folder(cfg), "features")
+
     logging.info(f"Temp directory: {temp_dir}")
 
     ############################################################################
@@ -462,29 +479,45 @@ def instance_retrieval_test(args, cfg):
     )
 
     ############################################################################
-    # Step 5: Compute similarity and score
+    # Step 5: Compute similarity, score, and save results
     logging.info("Calculating similarity and score...")
     sim = features_queries.dot(features_dataset.T)
     logging.info(f"Similarity tensor: {sim.shape}")
-    eval_dataset.score(sim, temp_dir)
+    results = eval_dataset.score(sim, temp_dir)
 
     ############################################################################
-    # Step 6: cleanup the temp directory
+    # Step 6: save results and cleanup the temp directory
+    if save_results:
+        sim = sim.T
+        ranks = np.argsort(-sim, axis=0)
+        save_file(
+            ranks.T.tolist(), os.path.join(get_checkpoint_folder(cfg), "rankings.json")
+        )
+
+        save_file(
+            sim.tolist(),
+            os.path.join(get_checkpoint_folder(cfg), "similarity_scores.json"),
+        )
+        save_file(results, os.path.join(get_checkpoint_folder(cfg), "metrics.json"))
+
     logging.info(f"Cleaning up temp directory: {temp_dir}")
-    cleanup_dir(temp_dir)
+
+    if not save_results:
+        cleanup_dir(temp_dir)
 
     logging.info("All done!!")
 
 
 def main(args: Namespace, config: AttrDict):
+    # setup the environment variables
+    set_env_vars(local_rank=0, node_id=0, cfg=config)
+
     # setup the logging
-    setup_logging(__name__)
+    checkpoint_folder = get_checkpoint_folder(config)
+    setup_logging(__name__, output_dir=checkpoint_folder)
 
     # print the config
     print_cfg(config)
-
-    # setup the environment variables
-    set_env_vars(local_rank=0, node_id=0, cfg=config)
 
     instance_retrieval_test(args, config)
     # close the logging streams including the filehandlers

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -1253,6 +1253,9 @@ config:
     EVAL_BINARY_PATH: ""
     # Path to a temporary directory to store features and scores
     TEMP_DIR: "/tmp/instance_retrieval/"
+    # Whether or not to save the results (metrics, rankings, similarity scores, and features)
+    # to the config.CHECKPOINT.DIR.
+    SAVE_RESULTS: False
     # Whether to apply PCA/whitening or not
     SHOULD_TRAIN_PCA_OR_WHITENING: True
     # gem | rmac | l2_norm

--- a/vissl/utils/instance_retrieval_utils/data_util.py
+++ b/vissl/utils/instance_retrieval_utils/data_util.py
@@ -286,7 +286,7 @@ class RevisitedInstanceRetrievalDataset:
     ready to be used in the code for retrieval evaluations.
     """
 
-    def __init__(self, dataset: str, dir_main: str):
+    def __init__(self, dataset: str, dir_main: str, num_samples=None):
         # Credits: https://github.com/filipradenovic/revisitop/blob/master/python/dataset.py#L6     # NOQA
 
         self.DATASETS = ["roxford5k", "rparis6k"]
@@ -307,7 +307,16 @@ class RevisitedInstanceRetrievalDataset:
         cfg["nq"] = len(cfg["qimlist"])
 
         cfg["dataset"] = dataset
+
         self.cfg = cfg
+
+        self.N_images = self.cfg["n"]
+        self.N_queries = self.cfg["nq"]
+
+        if num_samples is not None:
+            self.N_queries = min(self.N_queries, num_samples)
+            self.N_images = min(self.N_images, num_samples)
+
         logging.info(
             f"Dataset: {dataset}, images: {self.get_num_images()}, "
             f"queries: {self.get_num_query_images()}"
@@ -329,13 +338,13 @@ class RevisitedInstanceRetrievalDataset:
         """
         Number of images in the dataset
         """
-        return self.cfg["n"]
+        return self.N_images
 
     def get_num_query_images(self):
         """
         Number of query images in the dataset
         """
-        return self.cfg["nq"]
+        return self.N_queries
 
     def get_query_roi(self, i: int):
         """
@@ -363,6 +372,7 @@ class RevisitedInstanceRetrievalDataset:
             g["ok"] = np.concatenate([gnd[i]["easy"]])
             g["junk"] = np.concatenate([gnd[i]["junk"], gnd[i]["hard"]])
             gnd_t.append(g)
+
         mapE, apsE, mprE, prsE = compute_map(ranks, gnd_t, ks)
 
         # search for easy & hard
@@ -400,6 +410,16 @@ class RevisitedInstanceRetrievalDataset:
                 np.around(mprH * 100, decimals=2),
             )
         )
+
+        return {
+            "mAP": {"e": mapE, "m": mapM, "h": mapH},
+            "mp@k": {
+                "k": ks,
+                "e": mprE.tolist(),
+                "m": mprM.tolist(),
+                "h": mprH.tolist(),
+            },
+        }
 
 
 # Credits: https://github.com/facebookresearch/deepcluster/blob/master/eval_retrieval.py    # NOQA
@@ -486,8 +506,10 @@ class InstanceRetrievalImageLoader:
         # (https://github.com/python-pillow/Pillow/issues/835)
         with PathManager.open(img_path, "rb") as f:
             img = Image.open(f).convert("RGB")
+
         if roi is not None:
-            im_resized = img.crop(roi)
+            img = img.crop(roi)
+
         im_resized, _ = self.apply_img_transform(img)
         return im_resized
 

--- a/vissl/utils/instance_retrieval_utils/data_util.py
+++ b/vissl/utils/instance_retrieval_utils/data_util.py
@@ -485,12 +485,13 @@ class InstanceRetrievalImageLoader:
         """
         # Read image, get aspect ratio, and resize such as the largest side equals S
         with PathManager.open(fname, "rb") as f:
-            im = Image.open(f).convert(mode="RGB")
-        im_resized, ratio = self.apply_img_transform(im)
+            img = Image.open(f).convert(mode="RGB")
+        im_resized, ratio = self.apply_img_transform(img)
         # If there is a roi, adapt the roi to the new size and crop. Do not rescale
         # the image once again
         if roi is not None:
             # ROI format is (xmin,ymin,xmax,ymax)
+            roi = np.array(roi)
             roi = np.round(roi * ratio).astype(np.int32)
             im_resized = im_resized[:, roi[1] : roi[3], roi[0] : roi[2]]
         return im_resized
@@ -507,10 +508,14 @@ class InstanceRetrievalImageLoader:
         with PathManager.open(img_path, "rb") as f:
             img = Image.open(f).convert("RGB")
 
+        im_resized, ratio = self.apply_img_transform(img)
+        # If there is a roi, adapt the roi to the new size and crop. Do not rescale
+        # the image once again
         if roi is not None:
-            img = img.crop(roi)
-
-        im_resized, _ = self.apply_img_transform(img)
+            # ROI format is (xmin,ymin,xmax,ymax)
+            roi = np.array(roi)
+            roi = np.round(roi * ratio).astype(np.int32)
+            im_resized = im_resized[:, roi[1] : roi[3], roi[0] : roi[2]]
         return im_resized
 
 

--- a/vissl/utils/instance_retrieval_utils/evaluate.py
+++ b/vissl/utils/instance_retrieval_utils/evaluate.py
@@ -99,14 +99,17 @@ def compute_map(ranks, gnd, kappas):
     """
 
     map = 0.0
-    nq = len(gnd)  # number of queries
+    nq = ranks.shape[-1]  # number of queries
     aps = np.zeros(nq)
     pr = np.zeros(len(kappas))
     prs = np.zeros((nq, len(kappas)))
     nempty = 0
-
     for i in np.arange(nq):
         qgnd = np.array(gnd[i]["ok"])
+
+        # Remove pos database queries that are not in the prediction.
+        # this is only used in DEBUG_MODE where we limit the number of db images.
+        qgnd = qgnd[qgnd < ranks.shape[0]]
 
         # no positive images, skip from the average
         if qgnd.shape[0] == 0:
@@ -114,9 +117,15 @@ def compute_map(ranks, gnd, kappas):
             prs[i, :] = float("nan")
             nempty += 1
             continue
+            print(f"Skipping: {i}")
 
         try:
             qgndj = np.array(gnd[i]["junk"])
+
+            # Remove junk database queries that are not in the prediction.
+            # this is only used in DEBUG_MODE where we limit the number of db images.
+            qgndj = qgndj[qgndj < ranks.shape[0]]
+
         except Exception:
             qgndj = np.empty(0)
 

--- a/vissl/utils/instance_retrieval_utils/pca.py
+++ b/vissl/utils/instance_retrieval_utils/pca.py
@@ -50,7 +50,6 @@ class PCA(object):
         self.DVt = self.DVt.cuda()
 
     def apply(self, X):
-        logging.info("Applying PCA...")
         X = X - self.mean
         num = torch.mm(self.DVt, X.transpose(0, 1)).transpose(0, 1)
         return num
@@ -65,6 +64,6 @@ def train_and_save_pca(features, n_pca, pca_out_fname):
     pca = PCA(n_pca)
     pca.fit(features)
     logging.info(f"Saving PCA features to: {pca_out_fname}")
-    save_file(pca, pca_out_fname)
+    save_file(pca, pca_out_fname, log=False)
     logging.info(f"Saved PCA features to: {pca_out_fname}")
     return pca

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -51,7 +51,7 @@ def create_file_symlink(file1, file2):
         logging.info(f"Could NOT create symlink. Error: {e}")
 
 
-def save_file(data, filename, append_to_json=True):
+def save_file(data, filename, append_to_json=True, log=True):
     """
     Common i/o utility to handle saving data to various file formats.
     Supported:
@@ -59,7 +59,8 @@ def save_file(data, filename, append_to_json=True):
     Specifically for .json, users have the option to either append (default)
     or rewrite by passing in Boolean value to append_to_json.
     """
-    logging.info(f"Saving data to file: {filename}")
+    if log:
+        logging.info(f"Saving data to file: {filename}")
     file_ext = os.path.splitext(filename)[1]
     if file_ext in [".pkl", ".pickle"]:
         with PathManager.open(filename, "wb") as fopen:
@@ -83,7 +84,9 @@ def save_file(data, filename, append_to_json=True):
             fopen.flush()
     else:
         raise Exception(f"Saving {file_ext} is not supported yet")
-    logging.info(f"Saved data to file: {filename}")
+
+    if log:
+        logging.info(f"Saved data to file: {filename}")
 
 
 def load_file(filename, mmap_mode=None):


### PR DESCRIPTION
Summary:
1. Fix the gem post processing logic.

Before this change, the code assumes that each non-preprocessed feature tensor has the same tensor shape:

```
    if cfg.IMG_RETRIEVAL.FEATS_PROCESSING_TYPE == "gem":
        gem_out_fname = f"{out_dir}/{train_dataset_name}_GeM.npy"
        train_features = torch.tensor(np.concatenate(train_features))
```

This is not the case, since ROxford/RParis images do not have a standard size, hence the resx layers have different height and widths (but same number of channels). GeM pooling will transform an image of any shape to a shape of `(num_channels)`

The change performs gem_pooling on each individual images, as opposed to all the images at once. This should be fine because both gem and l2 normalization are to be performed per-image.

2. Transform before cropping to the bounding box (as opposed to after cropping).

The experiments show that this yields much better results. This is also what the deepcluster implentation uses: https://github.com/facebookresearch/deepcluster/blob/master/eval_retrieval.py#L44

```
Oxford: 61.57 / 41.74 / 14.33 vs. 69.65 / 48.51 / 16.41
Paris: 83.7 / 66.87 / 44.81 vs. 87.9 / 70.57 / 47.39
```
f288434289
f288438150

Differential Revision: D29993204

