### PR TITLE
Json append fix

### DIFF
--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -50,12 +50,6 @@ def create_file_symlink(file1, file2):
     except Exception as e:
         logging.info(f"Could NOT create symlink. Error: {e}")
 
-def Merge(dict1, dict2):
-    """
-    Utility function for save_file function to append dictionaries.
-    """
-    return(dict2.update(dict1))
-
 
 def save_file(data, filename, append_to_json=True):
     """
@@ -78,7 +72,7 @@ def save_file(data, filename, append_to_json=True):
             with PathManager.open(filename, "r+") as fopen:
                 file_data = json.load(fopen)
                 with PathManager.open(filename, "w") as fopen:
-                    Merge(data,file_data)
+                    file_data.update(data)
                     fopen.write(json.dumps(file_data, sort_keys=True) + "\n")
                     file.flush()
                     file.seek(0)

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -50,6 +50,12 @@ def create_file_symlink(file1, file2):
     except Exception as e:
         logging.info(f"Could NOT create symlink. Error: {e}")
 
+def Merge(dict1, dict2):
+    """
+    Utility function for save_file function to append dictionaries.
+    """
+    return(dict2.update(dict1))
+
 
 def save_file(data, filename, append_to_json=True):
     """
@@ -69,11 +75,13 @@ def save_file(data, filename, append_to_json=True):
             np.save(fopen, data)
     elif file_ext == ".json":
         if append_to_json:
-            with PathManager.open(filename, "w") as fopen:
-                open_object=json.load(fopen)
-                open_object.append(data)
-                fopen.write(json.dumps(data, sort_keys=True) + "\n")
-                fopen.flush()
+            with PathManager.open(filename, "r+") as fopen:
+                file_data = json.load(fopen)
+                with PathManager.open(filename, "w") as fopen:
+                    Merge(data,file_data)
+                    fopen.write(json.dumps(file_data, sort_keys=True) + "\n")
+                    file.flush()
+                    file.seek(0)
         else:
             with PathManager.open(filename, "w") as fopen:
                 fopen.write(json.dumps(data, sort_keys=True) + "\n")

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -51,13 +51,16 @@ def create_file_symlink(file1, file2):
         logging.info(f"Could NOT create symlink. Error: {e}")
 
 
-def save_file(data, filename, append_to_json=True, verbose=True):
+def save_file(data, filename, append_to_json=False, verbose=True):
     """
     Common i/o utility to handle saving data to various file formats.
     Supported:
         .pkl, .pickle, .npy, .json
     Specifically for .json, users have the option to either append (default)
     or rewrite by passing in Boolean value to append_to_json.
+    save_file is used to populate metrics.json and dataset_catalog.json.
+    In metrics.json we add new line delimated json objects while in 
+    dataset_catalog.json we add to the same json object.
     """
     if verbose:
         logging.info(f"Saving data to file: {filename}")

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -69,7 +69,9 @@ def save_file(data, filename, append_to_json=True):
             np.save(fopen, data)
     elif file_ext == ".json":
         if append_to_json:
-            with PathManager.open(filename, "a") as fopen:
+            with PathManager.open(filename, "w") as fopen:
+                open_object=json.load(fopen)
+                open_object.append(data)
                 fopen.write(json.dumps(data, sort_keys=True) + "\n")
                 fopen.flush()
         else:

--- a/vissl/utils/io.py
+++ b/vissl/utils/io.py
@@ -71,11 +71,11 @@ def save_file(data, filename, append_to_json=True):
         if append_to_json:
             with PathManager.open(filename, "r+") as fopen:
                 file_data = json.load(fopen)
-                with PathManager.open(filename, "w") as fopen:
-                    file_data.update(data)
-                    fopen.write(json.dumps(file_data, sort_keys=True) + "\n")
-                    file.flush()
-                    file.seek(0)
+            with PathManager.open(filename, "w") as fopen:
+                file_data.update(data)
+                fopen.write(json.dumps(file_data, sort_keys=True) + "\n")
+                fopen.flush()
+                fopen.seek(0)
         else:
             with PathManager.open(filename, "w") as fopen:
                 fopen.write(json.dumps(data, sort_keys=True) + "\n")


### PR DESCRIPTION
With respect to ```vissl/utils/io.py``` file, on using ```append_to_json=True``` in the ```save_file``` function (in its current state) appends another JSON object to an already existing one rendering the file unreadable.This also means that the append function is not behaving as it is meant to.

To reproduce the above, run the https://colab.research.google.com/github/facebookresearch/vissl/blob/stable/tutorials/Understanding_VISSL_Training_and_YAML_Config.ipynb in its current state, and check the ```dataset_catalog.json``` after running the cell https://colab.research.google.com/github/facebookresearch/vissl/blob/stable/tutorials/Understanding_VISSL_Training_and_YAML_Config.ipynb#scrollTo=M8Q6LCqaWjl1&line=10&uniqifier=1 , the very next cell raises an error.
Also mentioned in #373 , the remedy to this is to delete the ```dataset_catalog.json``` file as mentioned in https://github.com/facebookresearch/vissl/issues/373#issuecomment-889586387

With this PR, I have made changes to the append functionality so that it writes to the already existing JSON object instead of creating two (basically without destabilizing the JSON format) and thereby actually achieving the appending functionality. Demo of this: https://colab.research.google.com/drive/1DMNshw4NJGi2WmFq6x04YP-kgSJWV6QU?usp=sharing



