### PR TITLE
Extract oxford features and resize transform

### DIFF
--- a/vissl/data/dataset_catalog.py
+++ b/vissl/data/dataset_catalog.py
@@ -278,7 +278,9 @@ def get_data_files(split, dataset_config):
         # otherwise retrieve from the cataloag based on the dataset name
         else:
             data_info = VisslDatasetCatalog.get(data_names[idx])
-            assert len(data_info[data_split]) > 0, "data paths list is empty"
+            assert (
+                len(data_info[data_split]) > 0
+            ), f"data paths list for split: { data_split } is empty"
             check_data_exists(
                 data_info[data_split][0]
             ), f"Some data files dont exist: {data_info[data_split][0]}"

--- a/vissl/data/ssl_transforms/img_pil_resize_larger_side.py
+++ b/vissl/data/ssl_transforms/img_pil_resize_larger_side.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+import numpy as np
+from classy_vision.dataset.transforms import register_transform
+from classy_vision.dataset.transforms.classy_transform import ClassyTransform
+from PIL import Image
+
+
+@register_transform("ImgPilResizeLargerSide")
+class ImgPilResizeLargerSide(ClassyTransform):
+    def __init__(
+        self,
+        size: int,
+    ):
+        """
+        Resizes the larger side to "size". Note that the torchvision.Resize transform
+        crops the smaller edge to the provided size and is unable to crop the larger
+        side.
+        """
+        self.size = size
+
+    def __call__(self, img):
+        # Resize the longest side to self.size.
+        if self.resize_long:
+            img_size_hw = np.array((img.size[1], img.size[0]))
+            ratio = float(self.size) / np.max(img_size_hw)
+            new_size = tuple(np.round(img_size_hw * ratio).astype(np.int32))
+            img_resized = img.resize((new_size[1], new_size[0]), Image.BILINEAR)
+        else:
+            img_resized = self.transforms(img)
+
+        return img_resized
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "ImgPilResizeLargerSide":
+        """
+        Instantiates ImgPilRandomSolarize from configuration.
+
+        Args:
+            config (Dict): arguments for for the transform
+
+        Returns:
+            ImgPilRandomSolarize instance.
+        """
+        size = config.get("size", 1024)
+
+        return cls(size)


### PR DESCRIPTION
Summary:
1. Setup oxford feature extraction so that features can be reused in instance_retrieval_test.
2. Create ImgPilResize to resize LONGER side to 1024. Torchvision.Resize can only transform smaller side.

Differential Revision: D30179807

