### PR TITLE
Fix rmac invalid crop bug

### DIFF
--- a/vissl/utils/instance_retrieval_utils/rmac.py
+++ b/vissl/utils/instance_retrieval_utils/rmac.py
@@ -50,6 +50,11 @@ def get_rmac_region_coordinates(H, W, L):
     regions_xywh = []
     for l in range(1, L + 1):
         wl = np.floor(2 * w / (l + 1))
+
+        if wl == 0:
+            # Edge case when w == 1, the height/width will be made 0.
+            continue
+
         wl2 = np.floor(wl / 2 - 1)
         # Center coordinates
         if l + Wd - 1 > 0:
@@ -57,6 +62,7 @@ def get_rmac_region_coordinates(H, W, L):
         else:
             b = 0
         cenW = np.floor(wl2 + b * np.arange(l - 1 + Wd + 1)) - wl2
+
         # Center coordinates
         if l + Hd - 1 > 0:
             b = (H - wl) / (l + Hd - 1)
@@ -76,6 +82,7 @@ def get_rmac_region_coordinates(H, W, L):
             regions_xywh[i][0] -= (regions_xywh[i][0] + regions_xywh[i][2]) - W
         if regions_xywh[i][1] + regions_xywh[i][3] > H:
             regions_xywh[i][1] -= (regions_xywh[i][1] + regions_xywh[i][3]) - H
+
     return np.array(regions_xywh)
 
 
@@ -95,6 +102,7 @@ def get_rmac_descriptors(features, rmac_levels, pca=None, normalize=True):
     nr = len(rmac_regions)
 
     rmac_descriptors = []
+
     for x0, y0, w, h in rmac_regions:
         desc = features[:, :, y0 : y0 + h, x0 : x0 + w]
         desc = torch.max(desc, 2, keepdim=True)[0]


### PR DESCRIPTION
Summary: 1. Rmac region calculator were returning crops that were invalid. More specifically the crops returns a zero dim tensor. This happens when either the height or width is zero. Solution is to add these checks.

Differential Revision: D30226713

