### PR TITLE
Add more regnets to instance retrieval

### DIFF
--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -1280,6 +1280,8 @@ config:
     # image scale and averaged. Default is [1], meaning that only the full
     # image is processed.
     IMG_SCALINGS: [1]
+    # valid options are cosine_similarity (suggested) and l2.
+    SIMILARITY_MEASURE: "cosine_similarity"
     ######################## Features Processing Hypers #######################
     # Resize larger side of image to RESIZE_IMG pixels (e.g. 800)
     RESIZE_IMG: 1024


### PR DESCRIPTION
Summary:
1. Add all regnets for instance retrieval.
2. Add ability for l2 distance in addition to cosine similarity.
3. Some more experiments (test all regnets, res5avg, img size hypertuning, etc.,)

Differential Revision: D30308083

