### PR TITLE
ssl-framework: future compatibility with Hydra 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 cython==0.29.22
 fairscale@https://github.com/facebookresearch/fairscale/tarball/df7db85cef7f9c30a5b821007754b96eb1f977b6
 fvcore==0.1.3.post20210317
-hydra-core==1.0.6
+hydra-core==1.0.7
 numpy==1.19.5
 parameterized==0.7.4
 scikit-learn==0.24.1

--- a/tests/test_extract_cluster.py
+++ b/tests/test_extract_cluster.py
@@ -8,9 +8,8 @@ import os
 import shutil
 import unittest
 
-from hydra.experimental import compose, initialize_config_module
 from vissl.utils.cluster_utils import ClusterAssignmentLoader
-from vissl.utils.hydra_config import convert_to_attrdict
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.test_utils import (
     gpu_test,
     in_temporary_directory,
@@ -21,31 +20,29 @@ from vissl.utils.test_utils import (
 class TestExtractClusterWorkflow(unittest.TestCase):
     @staticmethod
     def _create_pretraining_config(with_fsdp: bool, num_gpu: int = 2):
-        with initialize_config_module(config_module="vissl.config"):
-            cfg = compose(
-                "defaults",
-                overrides=[
-                    "config=test/integration_test/quick_swav",
-                    "+config/pretrain/swav/models=regnet16Gf",
-                    "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.DATA_LIMIT=40",
-                    "config.SEED_VALUE=0",
-                    "config.MODEL.AMP_PARAMS.USE_AMP=False",
-                    "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
-                    "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
-                    "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
-                    "config.LOSS.swav_loss.epsilon=0.03",
-                    "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
-                    "config.MODEL.FSDP_CONFIG.mixed_precision=False",
-                    "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
-                    "config.MODEL.FSDP_CONFIG.compute_dtype=float32",
-                    f"config.DISTRIBUTED.NUM_PROC_PER_NODE={num_gpu}",
-                    "config.LOG_FREQUENCY=1",
-                    "config.OPTIMIZER.construct_single_param_group_only=True",
-                    "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
-                    "config.OPTIMIZER.use_larc=False",
-                ],
-            )
+        cfg = compose_hydra_configuration(
+            [
+                "config=test/integration_test/quick_swav",
+                "+config/pretrain/swav/models=regnet16Gf",
+                "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.DATA_LIMIT=40",
+                "config.SEED_VALUE=0",
+                "config.MODEL.AMP_PARAMS.USE_AMP=False",
+                "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
+                "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
+                "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
+                "config.LOSS.swav_loss.epsilon=0.03",
+                "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
+                "config.MODEL.FSDP_CONFIG.mixed_precision=False",
+                "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
+                "config.MODEL.FSDP_CONFIG.compute_dtype=float32",
+                f"config.DISTRIBUTED.NUM_PROC_PER_NODE={num_gpu}",
+                "config.LOG_FREQUENCY=1",
+                "config.OPTIMIZER.construct_single_param_group_only=True",
+                "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
+                "config.OPTIMIZER.use_larc=False",
+            ]
+        )
         args, config = convert_to_attrdict(cfg)
         if with_fsdp:
             config["MODEL"]["TRUNK"]["NAME"] = "regnet_fsdp"
@@ -60,37 +57,35 @@ class TestExtractClusterWorkflow(unittest.TestCase):
     def _create_extract_cluster_config(
         with_fsdp: bool, checkpoint_path: str, num_gpu: int = 2
     ):
-        with initialize_config_module(config_module="vissl.config"):
-            cfg = compose(
-                "defaults",
-                overrides=[
-                    "config=extract_cluster/swav/visualise_swav_resnet_in1k_8gpu",
-                    "+config/extract_cluster/swav/models=regnet16Gf",
-                    f"config.MODEL.WEIGHTS_INIT.PARAMS_FILE={checkpoint_path}",
-                    "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.LABEL_SOURCES=[synthetic]",
-                    "config.DATA.TEST.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TEST.LABEL_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.DATA_LIMIT=40",
-                    "config.DATA.TEST.DATA_LIMIT=20",
-                    "config.SEED_VALUE=0",
-                    "config.MODEL.AMP_PARAMS.USE_AMP=False",
-                    "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
-                    "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
-                    "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
-                    "config.LOSS.swav_loss.epsilon=0.03",
-                    "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
-                    "config.MODEL.FSDP_CONFIG.mixed_precision=False",
-                    "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
-                    "config.MODEL.FSDP_CONFIG.compute_dtype=float32",
-                    f"config.DISTRIBUTED.NUM_PROC_PER_NODE={num_gpu}",
-                    "config.LOG_FREQUENCY=1",
-                    "config.OPTIMIZER.construct_single_param_group_only=True",
-                    "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
-                    "config.DATA.TEST.BATCHSIZE_PER_REPLICA=4",
-                    "config.OPTIMIZER.use_larc=False",
-                ],
-            )
+        cfg = compose_hydra_configuration(
+            [
+                "config=extract_cluster/swav/visualise_swav_resnet_in1k_8gpu",
+                "+config/extract_cluster/swav/models=regnet16Gf",
+                f"config.MODEL.WEIGHTS_INIT.PARAMS_FILE={checkpoint_path}",
+                "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.LABEL_SOURCES=[synthetic]",
+                "config.DATA.TEST.DATA_SOURCES=[synthetic]",
+                "config.DATA.TEST.LABEL_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.DATA_LIMIT=40",
+                "config.DATA.TEST.DATA_LIMIT=20",
+                "config.SEED_VALUE=0",
+                "config.MODEL.AMP_PARAMS.USE_AMP=False",
+                "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
+                "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
+                "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
+                "config.LOSS.swav_loss.epsilon=0.03",
+                "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
+                "config.MODEL.FSDP_CONFIG.mixed_precision=False",
+                "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
+                "config.MODEL.FSDP_CONFIG.compute_dtype=float32",
+                f"config.DISTRIBUTED.NUM_PROC_PER_NODE={num_gpu}",
+                "config.LOG_FREQUENCY=1",
+                "config.OPTIMIZER.construct_single_param_group_only=True",
+                "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
+                "config.DATA.TEST.BATCHSIZE_PER_REPLICA=4",
+                "config.OPTIMIZER.use_larc=False",
+            ]
+        )
         args, config = convert_to_attrdict(cfg)
         if with_fsdp:
             config["MODEL"]["TRUNK"]["NAME"] = "regnet_fsdp"

--- a/tests/test_regnet_fsdp.py
+++ b/tests/test_regnet_fsdp.py
@@ -9,13 +9,12 @@ import unittest
 import torch
 import torch.multiprocessing as mp
 from classy_vision.optim import build_optimizer
-from hydra.experimental import compose, initialize_config_module
 from torch.nn.parallel import DistributedDataParallel
 from vissl.losses.swav_loss import SwAVLoss
 from vissl.models import build_model
 from vissl.optimizers import *  # noqa
 from vissl.utils.fsdp_utils import fsdp_wrapper
-from vissl.utils.hydra_config import convert_to_attrdict
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.test_utils import gpu_test, init_distributed_on_file, with_temp_files
 
 
@@ -29,24 +28,22 @@ class TestRegnetFSDP(unittest.TestCase):
     def _create_pretraining_config(
         with_fsdp: bool, with_activation_checkpointing: bool, with_larc: bool
     ):
-        with initialize_config_module(config_module="vissl.config"):
-            cfg = compose(
-                "defaults",
-                overrides=[
-                    "config=pretrain/swav/swav_8node_resnet",
-                    "+config/pretrain/swav/models=regnet16Gf",
-                    "config.SEED_VALUE=2",
-                    "config.MODEL.AMP_PARAMS.USE_AMP=True",
-                    "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
-                    "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
-                    "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
-                    f"config.OPTIMIZER.use_larc={with_larc}",
-                    "config.LOSS.swav_loss.epsilon=0.03",
-                    "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
-                    "config.MODEL.FSDP_CONFIG.mixed_precision=False",
-                    "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
-                ],
-            )
+        cfg = compose_hydra_configuration(
+            [
+                "config=pretrain/swav/swav_8node_resnet",
+                "+config/pretrain/swav/models=regnet16Gf",
+                "config.SEED_VALUE=2",
+                "config.MODEL.AMP_PARAMS.USE_AMP=True",
+                "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
+                "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
+                "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
+                f"config.OPTIMIZER.use_larc={with_larc}",
+                "config.LOSS.swav_loss.epsilon=0.03",
+                "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
+                "config.MODEL.FSDP_CONFIG.mixed_precision=False",
+                "config.MODEL.FSDP_CONFIG.fp32_reduce_scatter=False",
+            ],
+        )
         args, config = convert_to_attrdict(cfg)
         if with_fsdp:
             config["MODEL"]["TRUNK"]["NAME"] = "regnet_fsdp"

--- a/tests/test_regnet_fsdp_integration.py
+++ b/tests/test_regnet_fsdp_integration.py
@@ -6,9 +6,8 @@ import os
 import unittest
 
 import torch
-from hydra.experimental import compose, initialize_config_module
 from vissl.utils.checkpoint import CheckpointFormatConverter
-from vissl.utils.hydra_config import convert_to_attrdict
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.test_utils import (
     gpu_test,
     in_temporary_directory,
@@ -29,29 +28,27 @@ class TestRegnetFSDPIntegration(unittest.TestCase):
         with_mixed_precision: bool,
         auto_wrap_threshold: int,
     ):
-        with initialize_config_module(config_module="vissl.config"):
-            cfg = compose(
-                "defaults",
-                overrides=[
-                    "config=test/integration_test/quick_swav_2crops",
-                    "+config/test/integration_test/models=swav_regnet_fsdp",
-                    "config.SEED_VALUE=0",
-                    "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
-                    "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
-                    "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
-                    "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
-                    "config.LOSS.swav_loss.epsilon=0.03",
-                    "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
-                    "config.DATA.TRAIN.DATA_LIMIT=32",
-                    "config.DATA.TRAIN.USE_DEBUGGING_SAMPLER=True",
-                    "config.OPTIMIZER.use_larc=False",
-                    "config.OPTIMIZER.construct_single_param_group_only=True",
-                    "config.LOG_FREQUENCY=1",
-                    "config.REPRODUCIBILITY.CUDDN_DETERMINISTIC=True",
-                    "config.DISTRIBUTED.NUM_PROC_PER_NODE=2",
-                ],
-            )
+        cfg = compose_hydra_configuration(
+            [
+                "config=test/integration_test/quick_swav_2crops",
+                "+config/test/integration_test/models=swav_regnet_fsdp",
+                "config.SEED_VALUE=0",
+                "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
+                "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
+                "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
+                "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
+                "config.LOSS.swav_loss.epsilon=0.03",
+                "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
+                "config.DATA.TRAIN.DATA_LIMIT=32",
+                "config.DATA.TRAIN.USE_DEBUGGING_SAMPLER=True",
+                "config.OPTIMIZER.use_larc=False",
+                "config.OPTIMIZER.construct_single_param_group_only=True",
+                "config.LOG_FREQUENCY=1",
+                "config.REPRODUCIBILITY.CUDDN_DETERMINISTIC=True",
+                "config.DISTRIBUTED.NUM_PROC_PER_NODE=2",
+            ]
+        )
         args, config = convert_to_attrdict(cfg)
         if with_fsdp:
             config["MODEL"]["TRUNK"]["NAME"] = "regnet_fsdp"
@@ -74,33 +71,31 @@ class TestRegnetFSDPIntegration(unittest.TestCase):
     def _create_linear_evaluation_config(
         self, with_fsdp: bool, with_mixed_precision: bool, auto_wrap_threshold: int
     ):
-        with initialize_config_module(config_module="vissl.config"):
-            cfg = compose(
-                "defaults",
-                overrides=[
-                    "config=test/integration_test/quick_eval_in1k_linear",
-                    "+config/test/integration_test/models=eval_regnet_fsdp",
-                    "config.SEED_VALUE=0",
-                    "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
-                    "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
-                    "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
-                    "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
-                    "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.LABEL_SOURCES=[synthetic]",
-                    "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
-                    "config.DATA.TRAIN.DATA_LIMIT=32",
-                    "config.DATA.TEST.DATA_SOURCES=[synthetic]",
-                    "config.DATA.TEST.LABEL_SOURCES=[synthetic]",
-                    "config.DATA.TEST.BATCHSIZE_PER_REPLICA=4",
-                    "config.DATA.TEST.DATA_LIMIT=32",
-                    "config.DATA.TRAIN.USE_DEBUGGING_SAMPLER=True",
-                    "config.OPTIMIZER.use_larc=False",
-                    "config.OPTIMIZER.construct_single_param_group_only=True",
-                    "config.LOG_FREQUENCY=1",
-                    "config.REPRODUCIBILITY.CUDDN_DETERMINISTIC=True",
-                    "config.DISTRIBUTED.NUM_PROC_PER_NODE=2",
-                ],
-            )
+        cfg = compose_hydra_configuration(
+            [
+                "config=test/integration_test/quick_eval_in1k_linear",
+                "+config/test/integration_test/models=eval_regnet_fsdp",
+                "config.SEED_VALUE=0",
+                "config.MODEL.SYNC_BN_CONFIG.CONVERT_BN_TO_SYNC_BN=True",
+                "config.MODEL.SYNC_BN_CONFIG.SYNC_BN_TYPE=pytorch",
+                "config.MODEL.AMP_PARAMS.AMP_TYPE=pytorch",
+                "config.MODEL.FSDP_CONFIG.flatten_parameters=True",
+                "config.DATA.TRAIN.DATA_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.LABEL_SOURCES=[synthetic]",
+                "config.DATA.TRAIN.BATCHSIZE_PER_REPLICA=4",
+                "config.DATA.TRAIN.DATA_LIMIT=32",
+                "config.DATA.TEST.DATA_SOURCES=[synthetic]",
+                "config.DATA.TEST.LABEL_SOURCES=[synthetic]",
+                "config.DATA.TEST.BATCHSIZE_PER_REPLICA=4",
+                "config.DATA.TEST.DATA_LIMIT=32",
+                "config.DATA.TRAIN.USE_DEBUGGING_SAMPLER=True",
+                "config.OPTIMIZER.use_larc=False",
+                "config.OPTIMIZER.construct_single_param_group_only=True",
+                "config.LOG_FREQUENCY=1",
+                "config.REPRODUCIBILITY.CUDDN_DETERMINISTIC=True",
+                "config.DISTRIBUTED.NUM_PROC_PER_NODE=2",
+            ]
+        )
         args, config = convert_to_attrdict(cfg)
         if with_fsdp:
             config["MODEL"]["TRUNK"]["NAME"] = "regnet_fsdp"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,8 +9,8 @@ import sys
 from typing import Any, List
 
 import pkg_resources
-from hydra.experimental import compose, initialize_config_module
 from omegaconf import OmegaConf
+from vissl.utils.hydra_config import compose_hydra_configuration
 
 
 logger = logging.getLogger("vissl")
@@ -93,15 +93,13 @@ UNIT_TEST_CONFIGS = create_valid_input(
     list_config_files("config/test/cpu_test", exclude_folders=None)
 )
 
-initialize_config_module(config_module="vissl.config")
-
 
 class SSLHydraConfig(object):
     def __init__(self, overrides: List[Any] = None):
         self.overrides = []
         if overrides is not None and len(overrides) > 0:
             self.overrides.extend(overrides)
-        cfg = compose(config_name="defaults", overrides=self.overrides)
+        cfg = compose_hydra_configuration(self.overrides)
         self.default_cfg = cfg
 
     @classmethod

--- a/tools/cluster_features_and_label.py
+++ b/tools/cluster_features_and_label.py
@@ -17,7 +17,6 @@ from typing import Any, List, Optional
 import numpy as np
 import torch
 from fvcore.common.file_io import PathManager
-from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.data import build_dataset
 from vissl.hooks import default_hook_generator
@@ -25,7 +24,7 @@ from vissl.utils.checkpoint import get_checkpoint_folder
 from vissl.utils.distributed_launcher import launch_distributed
 from vissl.utils.env import set_env_vars, setup_path_manager
 from vissl.utils.extract_features_utils import ExtractedFeaturesLoader
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.io import save_file
 from vissl.utils.logger import setup_logging, shutdown_logging
 from vissl.utils.misc import is_faiss_available, set_seeds
@@ -221,8 +220,7 @@ def main(args: Namespace, cfg: AttrDict):
 
 
 def hydra_main(overrides: List[Any]):
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
     main(args, config)
 
@@ -244,5 +242,4 @@ if __name__ == "__main__":
     ```
     """
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     hydra_main(overrides=overrides)

--- a/tools/instance_retrieval_test.py
+++ b/tools/instance_retrieval_test.py
@@ -14,7 +14,6 @@ import torch
 import torchvision
 from classy_vision.generic.util import copy_model_to_gpu, load_checkpoint
 from fvcore.common.file_io import PathManager
-from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.models import build_model
 from vissl.utils.checkpoint import (
@@ -23,8 +22,8 @@ from vissl.utils.checkpoint import (
 )
 from vissl.utils.env import set_env_vars
 from vissl.utils.hydra_config import (
+    compose_hydra_configuration,
     convert_to_attrdict,
-    is_hydra_available,
     print_cfg,
 )
 from vissl.utils.instance_retrieval_utils.data_util import (
@@ -668,13 +667,11 @@ def main(args: Namespace, config: AttrDict):
 
 
 def hydra_main(overrides: List[Any]):
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
     main(args, config)
 
 
 if __name__ == "__main__":
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     hydra_main(overrides=overrides)

--- a/tools/launch_benchmark_suite_scheduler_slurm.py
+++ b/tools/launch_benchmark_suite_scheduler_slurm.py
@@ -10,7 +10,7 @@ import submitit
 from fvcore.common.file_io import PathManager
 from vissl.config.attr_dict import AttrDict
 from vissl.utils.benchmark_suite_scheduler import BenchmarkSuiteScheduler
-from vissl.utils.hydra_config import is_hydra_available
+from vissl.utils.hydra_config import assert_hydra_dependency
 from vissl.utils.io import load_file
 from vissl.utils.misc import recursive_dict_merge
 from vissl.utils.slurm import is_submitit_available
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     python -u "./vissl/engines/benchmark_suite_scheduler.py" \
         "/path/to/benchmark_suite_scheduler_example.json"
     """
-    assert is_hydra_available(), "Make sure to install hydra"
+    assert_hydra_dependency()
 
     assert (
         is_submitit_available()

--- a/tools/nearest_neighbor_test.py
+++ b/tools/nearest_neighbor_test.py
@@ -9,7 +9,6 @@ from argparse import Namespace
 from typing import Any, List
 
 import torch
-from hydra.experimental import compose, initialize_config_module
 from torch import nn
 from vissl.config import AttrDict
 from vissl.hooks import default_hook_generator
@@ -17,7 +16,11 @@ from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.utils.checkpoint import get_checkpoint_folder
 from vissl.utils.distributed_launcher import launch_distributed
 from vissl.utils.env import set_env_vars
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available, print_cfg
+from vissl.utils.hydra_config import (
+    compose_hydra_configuration,
+    convert_to_attrdict,
+    print_cfg,
+)
 from vissl.utils.logger import setup_logging, shutdown_logging
 from vissl.utils.misc import merge_features
 
@@ -125,13 +128,11 @@ def main(args: Namespace, config: AttrDict):
 
 
 def hydra_main(overrides: List[Any]):
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
     main(args, config)
 
 
 if __name__ == "__main__":
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     hydra_main(overrides=overrides)

--- a/tools/perf_measurement/benchmark_data.py
+++ b/tools/perf_measurement/benchmark_data.py
@@ -10,10 +10,9 @@ from typing import List
 import torch
 import tqdm
 from fvcore.common.timer import Timer
-from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.data import build_dataloader, build_dataset
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.logger import setup_logging
 
 
@@ -87,8 +86,7 @@ def benchmark_data(cfg: AttrDict, split: str = "train"):
 
 def hydra_main(overrides: List[str]):
     print(f"####### overrides: {overrides}")
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     setup_logging(__name__)
     args, config = convert_to_attrdict(cfg)
     benchmark_data(config)
@@ -96,6 +94,5 @@ def hydra_main(overrides: List[str]):
 
 if __name__ == "__main__":
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     overrides.append("hydra.verbose=true")
     hydra_main(overrides=overrides)

--- a/tools/run_distributed_engines.py
+++ b/tools/run_distributed_engines.py
@@ -12,12 +12,11 @@ Supports SLURM as an option. Set config.SLURM.USE_SLURM=true to use slurm.
 import sys
 from typing import Any, List
 
-from hydra.experimental import compose, initialize_config_module
 from vissl.utils.distributed_launcher import (
     launch_distributed,
     launch_distributed_on_slurm,
 )
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.slurm import is_submitit_available
 
 
@@ -31,8 +30,7 @@ def hydra_main(overrides: List[Any]):
     ######################################################################################
 
     print(f"####### overrides: {overrides}")
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
 
     if config.SLURM.USE_SLURM:
@@ -56,6 +54,5 @@ if __name__ == "__main__":
     `python tools/run_distributed_engines.py config=test/integration_test/quick_simclr`
     """
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     overrides.append("hydra.verbose=true")
     hydra_main(overrides=overrides)

--- a/tools/train_svm.py
+++ b/tools/train_svm.py
@@ -10,14 +10,17 @@ from argparse import Namespace
 from typing import Any, List
 
 import numpy as np
-from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.hooks import default_hook_generator
 from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.utils.checkpoint import get_checkpoint_folder
 from vissl.utils.distributed_launcher import launch_distributed
 from vissl.utils.env import set_env_vars
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available, print_cfg
+from vissl.utils.hydra_config import (
+    compose_hydra_configuration,
+    convert_to_attrdict,
+    print_cfg,
+)
 from vissl.utils.io import load_file
 from vissl.utils.logger import setup_logging, shutdown_logging
 from vissl.utils.misc import merge_features
@@ -93,13 +96,11 @@ def main(args: Namespace, config: AttrDict):
 
 
 def hydra_main(overrides: List[Any]):
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
     main(args, config)
 
 
 if __name__ == "__main__":
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     hydra_main(overrides=overrides)

--- a/tools/train_svm_low_shot.py
+++ b/tools/train_svm_low_shot.py
@@ -13,7 +13,6 @@ from extra_scripts.create_low_shot_samples import (
     generate_low_shot_samples,
     generate_places_low_shot_samples,
 )
-from hydra.experimental import compose, initialize_config_module
 from vissl.config import AttrDict
 from vissl.data import dataset_catalog
 from vissl.hooks import default_hook_generator
@@ -21,7 +20,11 @@ from vissl.models.model_helpers import get_trunk_output_feature_names
 from vissl.utils.checkpoint import get_checkpoint_folder
 from vissl.utils.distributed_launcher import launch_distributed
 from vissl.utils.env import set_env_vars
-from vissl.utils.hydra_config import convert_to_attrdict, is_hydra_available, print_cfg
+from vissl.utils.hydra_config import (
+    compose_hydra_configuration,
+    convert_to_attrdict,
+    print_cfg,
+)
 from vissl.utils.io import load_file
 from vissl.utils.logger import setup_logging, shutdown_logging
 from vissl.utils.misc import merge_features
@@ -239,13 +242,11 @@ def main(args: Namespace, cfg: AttrDict):
 
 
 def hydra_main(overrides: List[Any]):
-    with initialize_config_module(config_module="vissl.config"):
-        cfg = compose("defaults", overrides=overrides)
+    cfg = compose_hydra_configuration(overrides)
     args, config = convert_to_attrdict(cfg)
     main(args, config)
 
 
 if __name__ == "__main__":
     overrides = sys.argv[1:]
-    assert is_hydra_available(), "Make sure to install hydra"
     hydra_main(overrides=overrides)

--- a/vissl/config/defaults.yaml
+++ b/vissl/config/defaults.yaml
@@ -33,6 +33,7 @@
 #        +config/pretrain/simclr/my_sub_folder=my_file_name \
 #        +config.MY_NEW_KEY=MY_VALUE
 defaults:
+  - _self_
   # you must specify the base config you want to run
   - config: ???
 

--- a/vissl/utils/benchmark_suite_scheduler.py
+++ b/vissl/utils/benchmark_suite_scheduler.py
@@ -14,10 +14,9 @@ from typing import List
 
 import submitit
 from fvcore.common.file_io import PathManager
-from hydra.experimental import compose, initialize_config_module
 from vissl.config.attr_dict import AttrDict
 from vissl.utils.distributed_launcher import launch_distributed_on_slurm
-from vissl.utils.hydra_config import convert_to_attrdict
+from vissl.utils.hydra_config import compose_hydra_configuration, convert_to_attrdict
 from vissl.utils.io import load_file, makedir
 from vissl.utils.misc import flatten_dict, retry
 
@@ -608,11 +607,9 @@ class BenchmarkSuiteScheduler:
             "checkpoints",
         )
 
-    def _generate_config(self, config):
+    def _generate_config(self, overrides: List[str]):
         """
         Generate AttrDict config from a config YAML file and overrides.
         """
-        with initialize_config_module(config_module="vissl.config"):
-            config = compose("defaults", overrides=config)
-
-        return convert_to_attrdict(config)
+        cfg = compose_hydra_configuration(overrides)
+        return convert_to_attrdict(cfg)


### PR DESCRIPTION
Summary:
Updates necessary to update to Hydra 1.1.

## Composition order is changing

One of the changes in Hydra 1.1 is that the default composition order is changing. This is documented in: https://hydra.cc/docs/upgrades/1.0_to_1.1/default_composition_order.

In Hydra 1.1, a config is overriding values introduced by the defaults list while in Hydra 1.0 - the defaults list was overriding the values in the config.

The solution is to add `_self_` as the first item in the defaults list.

**Hydra 1.0.7**: As of Hydra 1.0.7, Hydra 1.0 ignores `_self_` in the defaults list. Adding it there does not change the behaviour of Hydra 1.0. This is the minimum version of Hydra supported by VISSL from this commit on. An assert has been added to ask users to upgrade.

**Hydra 1.1**: In Hydra 1.1, `_self_` determines the composition order of the content of a config relative to the items from its defaults list. Adding `_self_` as the first item ensures that the defaults list will override the config and not the other way around.

## Compose is not experimental anymore

Calls to `hydra.experimental.compose` will raise a warning starting from Hydra 1.1. The code has been adapted to make sure the correct version of compose is used in Hydra 1.1.

Differential Revision: D29778452

