### PR TITLE
Extract_cluster from DeepCluster_V2 pretrained model and visualisation (#364)

### DIFF
--- a/configs/config/extract_cluster/dc_v2/visualise_DCV2_resnet.yaml
+++ b/configs/config/extract_cluster/dc_v2/visualise_DCV2_resnet.yaml
@@ -1,0 +1,66 @@
+# @package _global_
+engine_name: extract_cluster
+config:
+  DATA:
+    NUM_DATALOADER_WORKERS: 5
+    TRAIN:
+      DATA_SOURCES: [disk_folder]
+      LABEL_SOURCES: [disk_folder]
+      DATASET_NAMES: [imagenette_160_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: 256
+        - name: CenterCrop
+          size: 224
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: False
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/imagenette_160/
+      ENABLE_QUEUE_DATASET: False
+    TEST:
+      DATA_SOURCES: [disk_folder]
+      LABEL_SOURCES: [disk_folder]
+      DATASET_NAMES: [imagenette_160_folder]
+      BATCHSIZE_PER_REPLICA: 32
+      TRANSFORMS:
+        - name: Resize
+          size: 256
+        - name: CenterCrop
+          size: 224
+        - name: ToTensor
+        - name: Normalize
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+      MMAP_MODE: False
+      COPY_TO_LOCAL_DISK: False
+      COPY_DESTINATION_DIR: /tmp/imagenette_160/
+      ENABLE_QUEUE_DATASET: False
+  MODEL:
+    FEATURE_EVAL_SETTINGS:
+      EVAL_MODE_ON: True
+      FREEZE_TRUNK_AND_HEAD: True
+      EVAL_TRUNK_AND_HEAD: True
+    TRUNK:
+      NAME: resnet
+      RESNETS:
+        DEPTH: 50
+    HEAD:
+      PARAMS: [
+        ["mlp", {"dims": [2048, 2048], "use_relu": True, "skip_last_layer_relu_bn": False}],
+        ["mlp", {"dims": [2048, 128]}],
+      ]  
+    WEIGHTS_INIT:
+      PARAMS_FILE: "specify the model weights"
+      STATE_DICT_KEY_NAME: classy_state_dict
+  DISTRIBUTED:
+    NUM_NODES: 1
+    NUM_PROC_PER_NODE: 4
+    RUN_ID: auto
+  MACHINE:
+    DEVICE: gpu
+  CHECKPOINT:
+    DIR: "/path/to/checkpoint_directory"

--- a/vissl/models/base_ssl_model.py
+++ b/vissl/models/base_ssl_model.py
@@ -13,7 +13,7 @@ from classy_vision.models import ClassyModel, register_model
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from vissl.config import AttrDict
 from vissl.data.collators.collator_helper import MultiDimensionalTensor
-from vissl.models.heads import SwAVPrototypesHead, get_model_head
+from vissl.models.heads import SwAVPrototypesHead, get_model_head, MLP
 from vissl.models.model_helpers import (
     get_trunk_output_feature_names,
     is_feature_extractor_model,
@@ -551,11 +551,11 @@ class BaseSSLMultiInputOutputModel(ClassyModel):
     def is_clustering_model(self):
         """
         Whether or not the model is a clustering model
-        (only supports SwAV for the moment)
+        (supports SwAV and DeepCluster_v2 for the moment)
         """
-        return len(self.heads) == 1 and any(
-            isinstance(module, SwAVPrototypesHead) for module in self.heads[0].modules()
-        )
+        return len(self.heads) == 1 or any(
+            isinstance(module, MLP) for module in self.heads[0].modules()) or any(
+            isinstance(module, SwAVPrototypesHead) for module in self.heads[0].modules())
 
     @property
     def num_classes(self):

--- a/vissl/trainer/trainer_main.py
+++ b/vissl/trainer/trainer_main.py
@@ -555,7 +555,7 @@ class SelfSupervisionTrainer(object):
                     num_images = input_sample["indices"].shape[0]
                     for idx in range(num_images):
                         image_index = input_sample["indices"][idx]
-                        cluster_assignments[image_index] = prototype_index[idx].item()
+                        cluster_assignments[image_index] = prototype_index.item()
             except StopIteration:
                 break
         return cluster_assignments


### PR DESCRIPTION
Summary:
# For DC_V2 Cluster_assignment_extraction + visualisation_yaml_config

This PR introduces:
1. Changes in the trainer_main.py and base_ssl_model.py to adjust the head configuration of DC_V2
2. Yaml file config to extract clusters from the DC_V2 train checkpoint.

My own doubts - 

Forgive me for my mistakes; I don't feel confident whether changing - 

1. prototype_index[idx].item() **to** prototype_index.item() is doing the correct job in base_ssl_model.py. I changed it because it was otherwise showing the error - _'IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number'_
2. I also understand that in DC_V2, we use multi clustering, and for that we there are multi heads (i.e., len(self.heads) >1).

This is as far as my understanding goes. Kindly improve it as I am in urgent need of the visualization of the DCV2 Cluster assignments.

Regards,
DC

Kind note - 
Rest we can proceed with cluster_assignments_to_dataset.py as given in the [link](https://github.com/facebookresearch/vissl/commit/a8622d7649e9392e13db4806e014f4048678e9ba)

## Interested parties

CC: @QuentinDuval, @iseessel 
