### PR TITLE
Fixed model suffix .torch.torch in convert_vissl_to_torchvision.py

### DIFF
--- a/extra_scripts/convert_vissl_to_torchvision.py
+++ b/extra_scripts/convert_vissl_to_torchvision.py
@@ -54,7 +54,10 @@ def convert_and_save_model(args, replace_prefix):
     logger.info(f"Converted model. Number of params: {len(converted_model.keys())}")
 
     # save the state
-    output_filename = f"converted_vissl_{args.output_name}.torch"
+    if args.output_name.endswith(".torch"):
+        output_filename = f"converted_vissl_{args.output_name}"
+    else:
+        output_filename = f"converted_vissl_{args.output_name}.torch"
     output_model_filepath = f"{args.output_dir}/{output_filename}"
     logger.info(f"Saving model: {output_model_filepath}")
     torch.save(converted_model, output_model_filepath)


### PR DESCRIPTION
When following the instructions from https://github.com/facebookresearch/vissl/blob/main/MODEL_ZOO.md#converting-vissl-to-torchvision, the resulting converted model will have a ".torch.torch" suffix. This is avoided by checking whether the user has provided a .torch suffix for the model name.