### PR TITLE
VISSL: make hydra version checking more robust

### DIFF
--- a/vissl/utils/hydra_config.py
+++ b/vissl/utils/hydra_config.py
@@ -5,6 +5,7 @@
 
 import logging
 import pprint
+import re
 import sys
 from typing import Any, List, Tuple
 
@@ -88,7 +89,7 @@ def is_hydra_available():
 def get_hydra_version() -> Tuple[int, ...]:
     import hydra
 
-    return tuple(int(x) for x in hydra.__version__.split("."))
+    return tuple(int(re.findall("\\d+", x)[0]) for x in hydra.__version__.split("."))
 
 
 def assert_hydra_dependency():


### PR DESCRIPTION
Summary:
Upstream hydra now is at "1.2.0dev1"
which the last component throws an exception with the current parsing scheme.
Here we restrict to the numeric portion which should suffice.
Another option may be to depend on packaging.version.parse().

Differential Revision: D31557803

