### PR TITLE
Fix doc build dependency issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,6 @@ sphinx_rtd_theme
 sphinx_markdown_tables
 mock
 opencv-python
-tensorboard
 hydra-core>=1.0
 faiss-gpu
 cython
@@ -19,7 +18,5 @@ tabulate
 pycocotools>=2.0.1
 fvcore
 iopath==0.1.9
-fairscale
-git+git://github.com/facebookresearch/ClassyVision.git
 https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torchvision-0.6.0%2Bcpu-cp37-cp37m-linux_x86_64.whl


### PR DESCRIPTION
Getting error: 

```
The conflict is caused by:
    The user requested termcolor
    fvcore 0.1.5.post20211023 depends on termcolor>=1.1
    The user requested termcolor
    fvcore 0.1.5.post20211019 depends on termcolor>=1.1
    The user requested termcolor
```

When trying to build the docs. Also fairscale instillation takes forever, as it tries to download all the versions. See https://readthedocs.org/projects/vissl/builds/15085989/.

We shouldn't need fairscale (among others) as dependencies to build the docs.

Testing:

Run build steps: https://readthedocs.org/projects/vissl/builds/15085989/ locally. (able to reproduce error).
Follow readme to build docs and look at them locally: https://github.com/facebookresearch/vissl/tree/main/docs

