### PR TITLE
Migrate off legacy CircleCI GPUs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ gpu: &gpu
     TERM: xterm
   machine:
     image: ubuntu-1604:201903-01
-  resource_class: gpu.medium  # Tesla M60
+  resource_class: gpu.nvidia.medium.multi  # Tesla T4
 
 # -------------------------------------------------------------------------------------
 # Re-usable commands

--- a/tests/test_regnet_fsdp.py
+++ b/tests/test_regnet_fsdp.py
@@ -189,4 +189,11 @@ class TestRegnetFSDP(unittest.TestCase):
                     result[3] = round(result[3], 5)
                     result[4] = round(result[4], 4)
                     results.append(result)
-            self.assertEqual(results[0], results[1], "DDP vs FSDP (LARC)")
+
+            self.assertEqual(
+                len(results[0]), len(results[1]), "DDP vs FSDP (LARC) Loss Lengths"
+            )
+
+            for i, ddp_result in enumerate(results[0]):
+                fsdp_result = results[1][i]
+                self.assertAlmostEqual(ddp_result, fsdp_result, places=5)


### PR DESCRIPTION
Summary:
Copied from task: T101565179

CircleCI has notified us that they on December 31st, 2021 all legacy GPU
resource classes will no longer be available. You are receiving this task as a
PoC for the facebookresearch/vissl repo (https://github.com/facebookresearch/vissl).

The legacy GPU resource classes are:
gpu.small (1x NVIDIA Tesla M60)
gpu.medium (2x NVIDIA Tesla M60)
gpu.large (4x NVIDIA Tesla M60)

Please migrate the CircleCI config for this repo to the NEW Multi GPU Resources,
which are available now and will be available after the above legacy resource
classes are removed.

NEW Multi GPU Resources
gpu.nvidia.small.multi (NVIDIA Tesla T4 2 GPU 4 vCPUs 15 GB RAM (2 GPUs)
gpu.nvidia.medium.multi (NVIDIA Tesla T4 4 GPU 8 vCPUs 30 GB RAM (4 GPUs)

Differential Revision: D33338255

