### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -75,6 +75,30 @@ class HomeSplash extends React.Component {
   }
 }
 
+
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl">
+      <div className="row">
+        <div className="col" style={{textAlign: 'center'}}>
+          <h2>Check it out in the intro video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/0Bt-1ei7yw"
+              title="Explain Like I'm 5: VISSL"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 class Index extends React.Component {
   render() {
     const {config: siteConfig, language = ''} = this.props;
@@ -224,6 +248,7 @@ conda install -c vissl -c iopath -c conda-forge -c pytorch -c defaults apex viss
     return (
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
+        <VideoContainer />
         <div className="mainContainer">
           <Features />
           <QuickStart />


### PR DESCRIPTION
## Summary

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc..

## Test plan
<img width="720" alt="image" src="https://user-images.githubusercontent.com/12485205/154542437-564ce3c7-d951-4bf4-84c9-d3390f6142ea.png">
