### PR TITLE
Fix food101 dataset creation crash

### DIFF
--- a/extra_scripts/datasets/create_food101_data_files.py
+++ b/extra_scripts/datasets/create_food101_data_files.py
@@ -79,7 +79,6 @@ class Food101:
                 self.targets.append(label)
                 self.images.append(
                     os.path.join(
-                        self.input_path,
                         self.IMAGE_FOLDER,
                         label,
                         image_file_name + self.IMAGE_EXT,


### PR DESCRIPTION
code folder structure doesn't match the csv one, it seems that adding self.input_path to the self.IMAGE_FOLDER caused it 