### PR TITLE
Update some more fbcode callsites to explicitly specify use_reentrant (#205)

### DIFF
--- a/vissl/models/model_helpers.py
+++ b/vissl/models/model_helpers.py
@@ -512,7 +512,7 @@ def get_trunk_forward_outputs(
             for m in filter(lambda x: isinstance(x, _bn_cls), feature_block.modules()):
                 m.track_running_stats = m.training
 
-            feat = checkpoint(feature_block, feat)
+            feat = checkpoint(feature_block, feat, use_reentrant=True)
 
             # Freeze the running stats in any BN layer
             # the checkpointing process will have to do another FW pass


### PR DESCRIPTION
Summary:
X-link: https://github.com/fairinternal/mmf-internal/pull/205

X-link: https://github.com/fairinternal/omnivore/pull/111

X-link: https://github.com/facebookresearch/mmf/pull/1311

X-link: https://github.com/facebookresearch/multimodal/pull/425

See https://www.internalfb.com/diff/D44690634

Differential Revision: D45512719

